### PR TITLE
Fix build errors with GCC

### DIFF
--- a/Core/Gameboy/Gameboy.cpp
+++ b/Core/Gameboy/Gameboy.cpp
@@ -400,10 +400,10 @@ LoadRomResult Gameboy::LoadRom(VirtualFile& romFile)
 		MessageManager::Log("File: " + romFile.GetFileName());
 		MessageManager::Log("Game: " + header.GetCartName());
 		MessageManager::Log("Cart Type: " + std::to_string(header.CartType));
-		switch((CgbFlag)((int)header.CgbFlag & 0xC0)) {
-			case CgbFlag::Gameboy: MessageManager::Log("Supports: Game Boy"); break;
-			case CgbFlag::GameboyColorSupport: MessageManager::Log("Supports: Game Boy Color (compatible with GB)"); break;
-			case CgbFlag::GameboyColorExclusive: MessageManager::Log("Supports: Game Boy Color only"); break;
+		switch((CgbCompat)((int)header.CgbFlag & 0xC0)) {
+			case CgbCompat::Gameboy: MessageManager::Log("Supports: Game Boy"); break;
+			case CgbCompat::GameboyColorSupport: MessageManager::Log("Supports: Game Boy Color (compatible with GB)"); break;
+			case CgbCompat::GameboyColorExclusive: MessageManager::Log("Supports: Game Boy Color only"); break;
 		}
 		if(header.SgbFlag == 0x03) {
 			MessageManager::Log("Supports: Super Game Boy");
@@ -432,11 +432,11 @@ GameboyModel Gameboy::GetEffectiveModel(GameboyHeader& header)
 	EmuSettings* settings = _emu->GetSettings();
 	GameboyConfig cfg = settings->GetGameboyConfig();
 	GameboyModel model = cfg.Model;
-	CgbFlag cgbFlag = (CgbFlag)((int)header.CgbFlag & 0xC0);
+	CgbCompat cgbFlag = (CgbCompat)((int)header.CgbFlag & 0xC0);
 	bool supportsSgb = header.SgbFlag == 0x03;
 	switch(model) {
 		case GameboyModel::AutoFavorGb:
-			if(cgbFlag == CgbFlag::GameboyColorExclusive) {
+			if(cgbFlag == CgbCompat::GameboyColorExclusive) {
 				model = GameboyModel::GameboyColor;
 			} else {
 				model = GameboyModel::Gameboy;
@@ -444,7 +444,7 @@ GameboyModel Gameboy::GetEffectiveModel(GameboyHeader& header)
 			break;
 
 		case GameboyModel::AutoFavorSgb:
-			if(cgbFlag == CgbFlag::GameboyColorExclusive) {
+			if(cgbFlag == CgbCompat::GameboyColorExclusive) {
 				model = GameboyModel::GameboyColor;
 			} else {
 				model = GameboyModel::SuperGameboy;
@@ -452,7 +452,7 @@ GameboyModel Gameboy::GetEffectiveModel(GameboyHeader& header)
 			break;
 
 		case GameboyModel::AutoFavorGbc:
-			if(supportsSgb && cgbFlag == CgbFlag::Gameboy) {
+			if(supportsSgb && cgbFlag == CgbCompat::Gameboy) {
 				model = GameboyModel::SuperGameboy;
 			} else {
 				model = GameboyModel::GameboyColor;

--- a/Core/Gameboy/GameboyHeader.h
+++ b/Core/Gameboy/GameboyHeader.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "pch.h"
 
-enum class CgbFlag : uint8_t
+enum class CgbCompat : uint8_t
 {
 	Gameboy = 0x00,
 	GameboyColorSupport = 0x80,
@@ -13,7 +13,7 @@ struct GameboyHeader
 	//Starts at 0x134
 	char Title[11];
 	char ManufacturerCode[4];
-	CgbFlag CgbFlag;
+	CgbCompat CgbFlag;
 	char LicenseeCode[2];
 	uint8_t SgbFlag;
 	uint8_t CartType;

--- a/Core/NES/BaseMapper.cpp
+++ b/Core/NES/BaseMapper.cpp
@@ -898,7 +898,7 @@ void BaseMapper::WriteVram(uint16_t addr, uint8_t value)
 
 bool BaseMapper::IsNes20()
 {
-	return _romInfo.NesHeader.GetRomHeaderVersion() == RomHeaderVersion::Nes2_0;
+	return _romInfo.Header.GetRomHeaderVersion() == RomHeaderVersion::Nes2_0;
 }
 
 //Debugger Helper Functions
@@ -1077,7 +1077,7 @@ void BaseMapper::GetRomFileData(vector<uint8_t> &out, bool asIpsFile, uint8_t* h
 		}
 	} else {
 		vector<uint8_t> newFile;
-		newFile.insert(newFile.end(), (uint8_t*)&_romInfo.NesHeader, ((uint8_t*)&_romInfo.NesHeader) + sizeof(NesHeader));
+		newFile.insert(newFile.end(), (uint8_t*)&_romInfo.Header, ((uint8_t*)&_romInfo.Header) + sizeof(NesHeader));
 		newFile.insert(newFile.end(), _prgRom, _prgRom + _prgSize);
 		if(HasChrRom()) {
 			newFile.insert(newFile.end(), _chrRom, _chrRom + _chrRomSize);

--- a/Core/NES/Debugger/NesDebugger.cpp
+++ b/Core/NES/Debugger/NesDebugger.cpp
@@ -471,7 +471,7 @@ void NesDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption 
 	uint32_t prgRomSize = _debugger->GetMemoryDumper()->GetMemorySize(MemoryType::NesPrgRom);
 	vector<uint8_t> rom = vector<uint8_t>(prgRom, prgRom + prgRomSize);
 	
-	NesHeader header = _mapper->GetRomInfo().NesHeader;
+	NesHeader header = _mapper->GetRomInfo().Header;
 	rom.insert(rom.begin(), (uint8_t*)&header, (uint8_t*)&header + sizeof(NesHeader));
 	
 	if(saveAsIps) {

--- a/Core/NES/Loaders/iNesLoader.cpp
+++ b/Core/NES/Loaders/iNesLoader.cpp
@@ -35,7 +35,7 @@ void iNesLoader::LoadRom(RomData& romData, vector<uint8_t>& romFile, NesHeader *
 	romData.Info.VsPpuModel = header.GetVsSystemPpuModel();
 	romData.Info.InputType = header.GetInputType();
 	romData.Info.HasTrainer = header.HasTrainer();
-	romData.Info.NesHeader = header;
+	romData.Info.Header = header;
 
 	romData.ChrRamSize = header.GetChrRamSize();
 	romData.SaveChrRamSize = header.GetSaveChrRamSize();

--- a/Core/NES/Mappers/Bandai/BandaiFcg.h
+++ b/Core/NES/Mappers/Bandai/BandaiFcg.h
@@ -51,7 +51,7 @@ protected:
 			//"It contains an internal 256-byte serial EEPROM (24C02) that is shared among all Datach games."
 			//"One game, Battle Rush: Build up Robot Tournament, has an additional external 128-byte serial EEPROM (24C01) on the game cartridge."
 			//"The NES 2.0 header's PRG-NVRAM field will only denote whether the game cartridge has an additional 128-byte serial EEPROM"
-			if(!IsNes20() || _romInfo.NesHeader.GetSaveRamSize() == 128) {
+			if(!IsNes20() || _romInfo.Header.GetSaveRamSize() == 128) {
 				_extraEeprom.reset(new Eeprom24C01(_console));
 			}
 			
@@ -65,7 +65,7 @@ protected:
 			//"INES Mapper 016 submapper 5: LZ93D50 ASIC and no or 256-byte serial EEPROM, banked CHR-ROM"
 			
 			//Add a 256 byte serial EEPROM (24C02)
-			if(!IsNes20() || (_romInfo.SubMapperID == 5 && _romInfo.NesHeader.GetSaveRamSize() == 256)) {
+			if(!IsNes20() || (_romInfo.SubMapperID == 5 && _romInfo.Header.GetSaveRamSize() == 256)) {
 				//Connect a 256-byte EEPROM for iNES roms, and when submapper 5 + 256 bytes of save ram in header
 				_standardEeprom.reset(new Eeprom24C02(_console));
 			}

--- a/Core/NES/Mappers/Homebrew/MagicFloor218.h
+++ b/Core/NES/Mappers/Homebrew/MagicFloor218.h
@@ -12,7 +12,7 @@ protected:
 		SelectPrgPage(0, 0);
 
 		if(GetMirroringType() == MirroringType::FourScreens) {
-			SetMirroringType(_romInfo.NesHeader.Byte6 & 0x01 ? MirroringType::ScreenBOnly : MirroringType::ScreenAOnly);
+			SetMirroringType(_romInfo.Header.Byte6 & 0x01 ? MirroringType::ScreenBOnly : MirroringType::ScreenAOnly);
 		}
 
 		uint16_t mask = 0;

--- a/Core/NES/Mappers/Homebrew/UnRom512.h
+++ b/Core/NES/Mappers/Homebrew/UnRom512.h
@@ -36,7 +36,7 @@ protected:
 			SetMirroringType(MirroringType::ScreenAOnly);
 			_enableMirroringBit = true;
 		} else {
-			switch(_romInfo.NesHeader.Byte6 & 0x09) {
+			switch(_romInfo.Header.Byte6 & 0x09) {
 				case 0: SetMirroringType(MirroringType::Horizontal); break;
 				case 1: SetMirroringType(MirroringType::Vertical); break;
 				case 8: SetMirroringType(MirroringType::ScreenAOnly); _enableMirroringBit = true; break;

--- a/Core/NES/Mappers/Nintendo/MMC5.h
+++ b/Core/NES/Mappers/Nintendo/MMC5.h
@@ -315,7 +315,7 @@ protected:
 	{
 		uint32_t size;
 		if(IsNes20()) {
-			size = _romInfo.NesHeader.GetSaveRamSize();
+			size = _romInfo.Header.GetSaveRamSize();
 		} else if(_romInfo.IsInDatabase) {
 			size = _romInfo.DatabaseInfo.SaveRamSize;
 		} else {
@@ -335,7 +335,7 @@ protected:
 	{
 		uint32_t size;
 		if(IsNes20()) {
-			size = _romInfo.NesHeader.GetWorkRamSize();
+			size = _romInfo.Header.GetWorkRamSize();
 		} else if(_romInfo.IsInDatabase) {
 			size = _romInfo.DatabaseInfo.WorkRamSize;
 		} else {

--- a/Core/NES/RomData.h
+++ b/Core/NES/RomData.h
@@ -88,7 +88,7 @@ struct NesRomInfo
 
 	HashInfo Hash = {};
 
-	NesHeader NesHeader = {};
+	NesHeader Header = {};
 	NsfHeader NsfInfo = {};
 	GameInfo DatabaseInfo = {};
 };

--- a/Utilities/Serializer.h
+++ b/Utilities/Serializer.h
@@ -426,44 +426,44 @@ public:
 		}
 	}
 
-	template<> void Stream(string& value, const char* name, int index)
-	{
-		string key = GetKey(name, index);
-
-		CheckDuplicateKey(key);
-
-		if(_format == SerializeFormat::Map) {
-			if(_saving) {
-				WriteMapFormat(key, value);
-			} else {
-				ReadMapFormat(key, value);
-			}
-		} else {
-			if(_saving) {
-				//Write key
-				_data.insert(_data.end(), key.begin(), key.end());
-				_data.push_back(0);
-
-				//Write string size
-				WriteValue((uint32_t)value.size());
-
-				//Write string content
-				_data.insert(_data.end(), value.begin(), value.end());
-			} else {
-				auto result = _values.find(key);
-				if(result != _values.end()) {
-					SerializeValue& savedValue = result->second;
-					value = string(savedValue.DataPtr, savedValue.DataPtr + savedValue.Size);
-				} else {
-					value = "";
-				}
-			}
-		}
-	}
-
 	void PushNamePrefix(const char* name, int index = -1);
 	void PopNamePrefix();
 	void SaveTo(ostream &file, int compressionLevel = 1);
 	bool LoadFrom(istream& file);
 	void LoadFromMap(unordered_map<string, SerializeMapValue>& map);
 };
+
+template<> inline void Serializer::Stream(string& value, const char* name, int index)
+{
+	string key = GetKey(name, index);
+
+	CheckDuplicateKey(key);
+
+	if(_format == SerializeFormat::Map) {
+		if(_saving) {
+			WriteMapFormat(key, value);
+		} else {
+			ReadMapFormat(key, value);
+		}
+	} else {
+		if(_saving) {
+			//Write key
+			_data.insert(_data.end(), key.begin(), key.end());
+			_data.push_back(0);
+
+			//Write string size
+			WriteValue((uint32_t)value.size());
+
+			//Write string content
+			_data.insert(_data.end(), value.begin(), value.end());
+		} else {
+			auto result = _values.find(key);
+			if(result != _values.end()) {
+				SerializeValue& savedValue = result->second;
+				value = string(savedValue.DataPtr, savedValue.DataPtr + savedValue.Size);
+			} else {
+				value = "";
+			}
+		}
+	}
+}

--- a/makefile
+++ b/makefile
@@ -127,7 +127,7 @@ run:
 clean:
 	rm -r -f $(COREOBJ)
 	rm -r -f $(UTILOBJ)
-	rm -r -f $(LINUXOBJ)
+	rm -r -f $(LINUXOBJ) $(LIBEVDEVOBJ)
 	rm -r -f $(SEVENZIPOBJ)
 	rm -r -f $(LUAOBJ)
 	rm -r -f $(DLLOBJ)


### PR DESCRIPTION
Opening notes:
- I know from the thread's opening post that you said you wouldn't review PRs, but since #1, I'm guessing "fix the build" PRs should be acceptable? Let me know if you'd like the changes submitted another way.
- I tested the final product, and it works correctly!
- Since the Makefile claims it's compatible with GCC, I'm assuming that my GCC—12.21—is stricter than older versions, and that's why the build is failing for me.
- Also, honestly, that's not a bad Makefile. Dare I say, a good one even!

This fixes building on my box with `make -j8 LTO=true USE_GCC=true`. I can provide specific compiler versions etc. if you want.

<details><summary>Fixed compile errors</summary>

```
In file included from Utilities/Serializer.cpp:3:
Utilities/Serializer.h:429:18: error: explicit specialization in non-namespace scope ‘class Serializer’
  429 |         template<> void Stream(string& value, const char* name, int index)
      |                  ^
```
```
Core/Gameboy/GameboyHeader.h:16:17: error: declaration of ‘CgbFlag GameboyHeader::CgbFlag’ changes meaning of ‘CgbFlag’ [-fpermissive]
   16 |         CgbFlag CgbFlag;
      |                 ^~~~~~~
Core/Gameboy/GameboyHeader.h:4:12: note: ‘CgbFlag’ declared here as ‘enum class CgbFlag’
    4 | enum class CgbFlag : uint8_t
      |            ^~~~~~~
```
```
Core/NES/RomData.h:91:19: error: declaration of ‘NesHeader NesRomInfo::NesHeader’ changes meaning of ‘NesHeader’ [-fpermissive]
   91 |         NesHeader NesHeader = {};
      |                   ^~~~~~~~~
In file included from Core/NES/RomData.h:5:
Core/NES/NesHeader.h:6:8: note: ‘NesHeader’ declared here as ‘struct NesHeader’
    6 | struct NesHeader
      |        ^~~~~~~~~
```

</details>

Also, unrelated, but I can set up GH Actions CI in a separate PR. If you are interested.