### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,89 @@
+name: Build Mesen2
+
+on: [push, pull_request]
+
+env:
+  # I'm not a fan of the telemetry as-is, but this also suppresses some lines in the build log.
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  windows:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+      fail-fast: false
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.x
+
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          msbuild-architecture: x64
+
+      - name: Execute unit tests
+        run: dotnet test -nologo
+
+      - name: Build Mesen
+        run: msbuild -nologo -v:d -clp:ForceConsoleColor -m -p:Configuration=${{ matrix.configuration }} -p:Platform=x64 -t:UI # Avoid building e.g. `PGOHelper`.
+
+      - name: Upload Mesen
+        uses: actions/upload-artifact@v3
+        with:
+          name: Mesen2 for Windows (${{ matrix.configuration }})
+          path: |
+            bin/x64/${{ matrix.configuration }}/Mesen.exe
+            bin/x64/${{ matrix.configuration }}/Mesen.dll
+
+
+  linux:
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            use_gcc: "USE_GCC=true"
+          - compiler: clang
+            use_gcc: ""
+      fail-fast: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.x
+
+      - name: Install dependencies
+        run: sudo apt-get install -qy libsdl2-dev # The compilers are already installed on GitHub's runners.
+
+      - name: Execute unit tests
+        run: dotnet test --nologo
+
+      # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
+      # forcing colours makes the log a little nicer to read.
+      # Note that forcing `CC` and `CXX` bypasses `USE_GCC`.
+      - name: Build Mesen
+        run: | # FIXME: Must `make` twice because some libraries are not copied on the first run.
+          make -j$(nproc) -O MESENFLAGS="-fdiagnostics-color=always" ${{ matrix.use_gcc }} LTO=true STATICLINK=true SYSTEM_LIBEVDEV=false
+          make -j$(nproc) -O
+
+      - name: Upload Mesen
+        uses: actions/upload-artifact@v3
+        with:
+          name: Mesen2 for Linux (built with ${{ matrix.compiler }})
+          path: bin/x64/Release/linux-x64/publish/Mesen


### PR DESCRIPTION
Builds on Windows in Debug & Release mode, and on Linux in Release mode with each compiler & LTO enabled.

This may not be optimal/ideal: I have tried trimming the amount of work and unnecessary output down (e.g. `--nologo` where appropriate, passing `-t:UI` on Windows to avoid building `PGOHelper` et al.), but you are likely more proficient with MS' tools than I am, so you may spot mistakes that I made. (The [MSBuild CLI reference](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022) proved helpful.)

The Linux binaries run (at least, they show the initial dialog, but they crash after that due to an exception that reproduces outside of CI). The Windows binaries at least *launch*, but they complain about .NET missing (and I don't want to install .NET in Wine), so no further testing from me. Hopefully you can download [the artifacts](https://github.com/ISSOtm/Mesen2/actions/runs/4036985262) and test yourself?

It would be nice for CI to also check that Mesen at least runs, but since it's primarily a GUI application, I don't know if that's possible at all.

Oh, I also enabled colour output in the logs, since GitHub supports that. Makes them easier to read.