### PR TITLE
Fix up Linux CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on: [push]
 env:
   # I'm not a fan of the telemetry as-is, but this also suppresses some lines in the build log.
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  # This removes even more spurious lines.
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
 jobs:
   windows:
@@ -47,8 +49,20 @@ jobs:
 
   linux:
     strategy:
+      matrix:
+        compiler: [gcc, clang]
+        os: [ubuntu-22.04, ubuntu-20.04]
+        exclude:
+          # This currently fails to build.
+          - os: ubuntu-20.04
+            compiler: gcc
+        include:
+          - compiler: gcc
+            use_gcc: "USE_GCC=true"
+          - compiler: clang
+            use_gcc: ""
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repo
@@ -62,14 +76,15 @@ jobs:
           dotnet-version: 6.x
 
       - name: Install dependencies
-        run: sudo apt-get install -qy libsdl2-dev # The compilers are already installed on GitHub's runners.
+        run: |
+          sudo apt-get update -qy
+          sudo apt-get install -qy libsdl2-dev # The compilers are already installed on GitHub's runners.
 
       - name: Execute unit tests
         run: dotnet test --nologo
 
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.
-      # Note that forcing `CC` and `CXX` bypasses `USE_GCC`.
       - name: Build Mesen
         run: | # FIXME: Must `make` twice because some libraries are not copied on the first run.
           make -j$(nproc) -O MESENFLAGS="-fdiagnostics-color=always" LTO=true STATICLINK=true SYSTEM_LIBEVDEV=false
@@ -78,48 +93,5 @@ jobs:
       - name: Upload Mesen
         uses: actions/upload-artifact@v3
         with:
-          name: Mesen (Linux - Ubuntu 20.04 - clang)
+          name: Mesen (Linux - ${{ matrix.os }} - ${{ matrix.compiler }})
           path: bin/x64/Release/linux-x64/publish/Mesen
-
-  linux-ubuntu-latest:
-    strategy:
-      matrix:
-        compiler: [gcc, clang]
-        include:
-          - compiler: gcc
-            use_gcc: "USE_GCC=true"
-          - compiler: clang
-            use_gcc: ""
-      fail-fast: false
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install .NET Core
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.x
-
-      - name: Install dependencies
-        run: sudo apt-get install -qy libsdl2-dev # The compilers are already installed on GitHub's runners.
-
-      - name: Execute unit tests
-        run: dotnet test --nologo
-
-      # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
-      # forcing colours makes the log a little nicer to read.
-      # Note that forcing `CC` and `CXX` bypasses `USE_GCC`.
-      - name: Build Mesen
-        run: | # FIXME: Must `make` twice because some libraries are not copied on the first run.
-          make -j$(nproc) -O MESENFLAGS="-fdiagnostics-color=always" ${{ matrix.use_gcc }} LTO=true STATICLINK=true SYSTEM_LIBEVDEV=false
-          make -j$(nproc) -O
-
-      - name: Upload Mesen
-        uses: actions/upload-artifact@v3
-        with:
-          name: Mesen (Linux - Ubuntu 22.04 - ${{ matrix.compiler }})
-          path: bin/x64/Release/linux-x64/publish/


### PR DESCRIPTION
- Coalesce Linux jobs (keeping the GCC on Ubuntu 20 combo disabled, at least for now)
- Update APT database before grabbing packages (otherwise we might get spurious failures, oops!)
- Also disable the .NET "first time experience" which is just annoying here.