### PR TITLE
Use sdl2-config for SDL2 includes (fixes compilation on ARM Macs with homebrew SDL2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ build/
 [Oo]bj/
 [Oo]bj.x86/
 [Oo]bj.x64/
+[Oo]bj.linux-*/
+[Oo]bj.osx-*/
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/

--- a/Linux/SdlRenderer.h
+++ b/Linux/SdlRenderer.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include "Core/Shared/Interfaces/IRenderingDevice.h"
 #include "Utilities/SimpleLock.h"
 #include "Core/Shared/Video/VideoRenderer.h"

--- a/Linux/SdlSoundManager.h
+++ b/Linux/SdlSoundManager.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include "Core/Shared/Audio/BaseSoundManager.h"
 
 class Emulator;

--- a/makefile
+++ b/makefile
@@ -18,7 +18,10 @@ else
 	PROFILE_USE_FLAG = -fprofile-instr-use=$(CURDIR)/PGOHelper/pgo.profdata
 endif
 
-CXXFLAGS=-fPIC -Wall --std=c++17 -O3 $(MESENFLAGS) -I/usr/include/SDL2 -I $(realpath ./) -I $(realpath ./Core) -I $(realpath ./Utilities) -I $(realpath ./Linux)
+SDL2LIB=$(shell sdl2-config --libs)
+SDL2INC=$(shell sdl2-config --cflags)
+
+CXXFLAGS=-fPIC -Wall --std=c++17 -O3 $(MESENFLAGS) $(SDL2INC) -I $(realpath ./) -I $(realpath ./Core) -I $(realpath ./Utilities) -I $(realpath ./Linux)
 CFLAGS=-fPIC -Wall -O3 $(MESENFLAGS)
 
 LINKCHECKUNRESOLVED=-Wl,-z,defs 
@@ -104,8 +107,6 @@ else
 	LIBEVDEVINC=-I../
 endif
 
-SDL2LIB=$(shell sdl2-config --libs)
-SDL2INC=$(shell sdl2-config --cflags)
 FSLIB=-lstdc++fs
 
 ifeq ($(MESENOS),osx)


### PR DESCRIPTION
The Makefile is currently hardcoding the path to the SDL2 headers, and on ARM Macs this is not where homebrew puts SDL2. This pull request updates it to use `sdl2-config --cflags` instead. The Makefile already called this, but only used it when linking the object together and not when compiling the source files.

Additionally, the headers that include SDL2 included it by `<SDL2/SDL.h>`, while `sdl2-config`'s output assumes `"SDL.h"` instead, so this was updated as well.

Also added build files for Linux and macOS to the .gitignore.