### PR TITLE
Linux-related Avalonia/UI bugfix.

### DIFF
--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.ReactiveUI;
+using Avalonia.Media;
 using Mesen.Config;
 using Mesen.Utilities;
 using System;
@@ -159,6 +160,7 @@ namespace Mesen
 					.UseReactiveUI()
 					.UsePlatformDetect()
 					.With(new Win32PlatformOptions { AllowEglInitialization = true, UseWgl = useWgl })
+					.With(new FontManagerOptions() { DefaultFamilyName = "Liberation Mono" })
 					.With(new X11PlatformOptions { UseGpu = true, UseEGL = false })
 					.With(new AvaloniaNativePlatformOptions { UseGpu = true })
 					.LogToTrace();

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -78,6 +78,8 @@
     <PackageReference Include="Dock.Model.ReactiveUI" Version="11.0.0-preview3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="ReactiveUI.Fody" Version="18.4.1" />
+	 <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" ExcludeAssets="all"/>
+	 <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
    </ItemGroup>
   <ItemGroup>
     <Compile Update="Controls\ButtonWithIcon.axaml.cs">


### PR DESCRIPTION
Avalonia bug documented at https://github.com/AvaloniaUI/Avalonia/issues/4427.
Changes herein allow this to build on both Gentoo and Arch Linux.

Should you wish to change the default font to a microsoft default, please set an alternate font like Liberation or DejaVu in case a linux user didn't install corefonts.