### PR TITLE
macOS: Prevent alert sound on keypresses

### DIFF
--- a/UI/Debugger/Utilities/DebugShortcutManager.cs
+++ b/UI/Debugger/Utilities/DebugShortcutManager.cs
@@ -66,6 +66,7 @@ namespace Mesen.Debugger.Utilities
 
 								if(act.IsEnabled == null || act.IsEnabled()) {
 									act.OnClick();
+									e.Handled = true;
 								}
 							}
 						}

--- a/UI/Windows/MainWindow.axaml.cs
+++ b/UI/Windows/MainWindow.axaml.cs
@@ -519,6 +519,11 @@ namespace Mesen.Windows
 			return false;
 		}
 
+		private static bool IsModifierKey(Key key)
+		{
+			return key == Key.LeftShift || key == Key.LeftCtrl || key == Key.LeftAlt || key == Key.RightShift || key == Key.RightCtrl || key == Key.RightAlt;
+		}
+
 		private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
 		{
 			if(_testModeEnabled && e.KeyModifiers == KeyModifiers.Alt && ProcessTestModeShortcuts(e.Key)) {
@@ -537,6 +542,11 @@ namespace Mesen.Windows
 
 			if(e.Key == Key.Tab || e.Key == Key.F10) {
 				//Prevent menu/window from handling these keys to avoid issue with custom shortcuts
+				e.Handled = true;
+			}
+
+			if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !IsModifierKey(e.Key) && e.KeyModifiers != KeyModifiers.Meta) {
+				//Prevent alert sound on macOS
 				e.Handled = true;
 			}
 		}


### PR DESCRIPTION
This pull request makes some changes to prevent macOS from making an alert sound on every keypress. It does this by setting `Handled` on some key-events to true.

This happens in DebugShortcutManager, when `Click` is called on an action (currently unconditionally), and in the key-handler for the main window, where it happens on any keypress that is not a modifier key and does not have the meta-key (Command) active, here only when running on macOS (not setting on Command is to prevent it blocking Cmd-Q and such).

Note that not setting it on modifier keys is to work around an issue where, when Handled is set, dual-modifier keys drops the event for that third key entirely (e.g. CTRL+ALT+R) (but only when pressed in certain orders, ALT+CTRL+R works fine). This affects the window for setting up shortcuts as well, but I did not look into changing it there.