### PR TITLE
Add macos codesigning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
           CERT_DATA: ${{ secrets.MACOS_CERTIFICATE }}
           CERT_PASS: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           ENTITLEMENTS: UI/Mesen.entitlements
-          SIGNING_IDENTITY: TestSign
+          SIGNING_IDENTITY: Mesen
         run: |
           # Export certs
           echo "$CERT_DATA" | base64 --decode > /tmp/certs.p12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,31 @@ jobs:
         run: |
           make -j$(nproc)
 
+      - name: Sign binary
+        env:
+          APP_NAME: bin/osx-x64/Release/osx-x64/publish/Mesen.app
+          CERT_DATA: ${{ secrets.MACOS_CERTIFICATE }}
+          CERT_PASS: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          ENTITLEMENTS: UI/Mesen.entitlements
+          SIGNING_IDENTITY: TestSign
+        run: |
+          # Export certs
+          echo "$CERT_DATA" | base64 --decode > /tmp/certs.p12
+          # Create keychain
+          security create-keychain -p actions macos-build.keychain
+          security default-keychain -s macos-build.keychain
+          security unlock-keychain -p actions macos-build.keychain
+          security set-keychain-settings -t 3600 -u macos-build.keychain
+          # Import certs to keychain
+          security import /tmp/certs.p12 -k ~/Library/Keychains/macos-build.keychain -P "$CERT_PASS" -T /usr/bin/codesign -T /usr/bin/productsign
+          # Key signing
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions macos-build.keychain
+          # print identities
+          security find-identity -v macos-build.keychain
+
+          echo "[INFO] Signing app file"
+          codesign --force --deep --timestamp --keychain macos-build.keychain --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_NAME"
+
       - name: Zip Mesen.app
         run: |
           ditto -c -k --sequesterRsrc --keepParent bin/osx-x64/Release/osx-x64/publish/Mesen.app bin/osx-x64/Release/Mesen.app.zip

--- a/UI/Mesen.entitlements
+++ b/UI/Mesen.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Allows the uploaded macos `.app` artifact to be used on other machines. I setup the actions on my fork and tested the downloaded artifact. Note that this is selfsigned, so users will need to bypass gatekeeper to allow this to run. You have to pay $99/yr to get around that restriction...

This change requires creating a self signed certificate, and also requires a few changes to match the data you used when creating the certificate.

This guide explains how to set it up for a Apple Developer Account certificate (which costs $99/yr ...) but you can slightly change he instructions to get a self signed certificate. https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions

Instead of requesting the certificate from a certificate authority, choose `Create a Certificate...` instead. The name you choose at this stage will be the `SIGNING_IDENTITY` below. I used `TestSign` as the name if you feel lazy and don't want to change the build.yml file, you can keep that name the same. Also if you want, you can manually configure the certificate to up the number of days before it expires, and choose to use more bits in RSA.

After that, you need to export it as a `.p12` file by highlighting both the certificate and the private key, then right clicking and choosing "Export 2 items" and exporting the filetype `.p12`. It will prompt for a password, and this will be `MACOS_CERTIFICATE_PWD`

===

So to summarize, you need to change/add the following for this PR to work.
Edit the `build.yml` file and update `SIGNING_IDENTITY` to be the name you chose when making the certificate.

You will need these two secrets on the repo in github.
MACOS_CERTIFICATE - the base64 encoded data from the p12 file
MACOS_CERTIFICATE_PWD - the password you used when exporting the certificate.