### PR TITLE
Add WLA-DX V2 symbol (.sym) support

### DIFF
--- a/UI/Debugger/Integration/WlaDxImporter.cs
+++ b/UI/Debugger/Integration/WlaDxImporter.cs
@@ -18,6 +18,8 @@ public class WlaDxImporter : ISymbolProvider
 	private static Regex _labelRegex = new Regex(@"^([0-9a-fA-F]{2,4}):([0-9a-fA-F]{4}) ([^\s]*)", RegexOptions.Compiled);
 	private static Regex _fileRegex = new Regex(@"^([0-9a-fA-F]{4}) ([0-9a-fA-F]{8}) (.*)", RegexOptions.Compiled);
 	private static Regex _addrRegex = new Regex(@"^([0-9a-fA-F]{2,4}):([0-9a-fA-F]{4}) ([0-9a-fA-F]{4}):([0-9a-fA-F]{8})", RegexOptions.Compiled);
+	private static Regex _fileV2Regex = new Regex(@"^([0-9a-fA-F]{4}):([0-9a-fA-F]{4}) ([0-9a-fA-F]{8}) (.*)", RegexOptions.Compiled);
+	private static Regex _addrV2Regex = new Regex(@"^([0-9a-fA-F]{8}) ([0-9a-fA-F]{2}):([0-9a-fA-F]{4}) ([0-9a-fA-F]{4}) ([0-9a-fA-F]{4}):([0-9a-fA-F]{4}):([0-9a-fA-F]{8})", RegexOptions.Compiled);
 
 	private Dictionary<int, SourceFileInfo> _sourceFiles = new Dictionary<int, SourceFileInfo>();
 	private Dictionary<string, AddressInfo> _addressByLine = new Dictionary<string, AddressInfo>();
@@ -155,14 +157,25 @@ public class WlaDxImporter : ISymbolProvider
 						break;
 					}
 				}
-			} else if(str == "[source files]") {
+			} else if(str == "[source files]" || str == "[source files v2]") {
+				int file_idx = 1;
+				int path_idx = 3;
+				ref Regex regex = ref _fileRegex;
+
+				// Conversion of indices for supporting WLA-DX V2
+				if (str == "[source files v2]") {
+					file_idx = 2;
+					path_idx = 4;
+					regex = ref _fileV2Regex;
+				}
+
 				for(; i < lines.Length; i++) {
 					if(lines[i].Length > 0) {
-						Match m = _fileRegex.Match(lines[i]);
+						Match m = regex.Match(lines[i]);
 						if(m.Success) {
-							int fileId = Int32.Parse(m.Groups[1].Value, System.Globalization.NumberStyles.HexNumber);
+							int fileId = Int32.Parse(m.Groups[file_idx].Value, System.Globalization.NumberStyles.HexNumber);
 							//int fileCrc = Int32.Parse(m.Groups[2].Value, System.Globalization.NumberStyles.HexNumber);
-							string filePath = m.Groups[3].Value;
+							string filePath = m.Groups[path_idx].Value;
 
 							string fullPath = Path.Combine(basePath, filePath);
 							_sourceFiles[fileId] = new SourceFileInfo(filePath, true, new WlaDxFile() { Data = File.Exists(fullPath) ? File.ReadAllLines(fullPath) : new string[0] });
@@ -171,16 +184,31 @@ public class WlaDxImporter : ISymbolProvider
 						break;
 					}
 				}
-			} else if(str == "[addr-to-line mapping]") {
+			} else if(str == "[addr-to-line mapping]" || str == "[addr-to-line mapping v2]") {
+				int bank_idx = 1;
+				int addr_idx = 2;
+				int field_idx = 3;
+				int line_idx = 4;
+				ref Regex regex = ref _addrRegex;
+
+				// Conversion of indices for supporting WLA-DX V2
+				if (str == "[addr-to-line mapping v2]") {
+					bank_idx = 2;
+					addr_idx = 3;
+					field_idx = 6;
+					line_idx = 7;
+					regex = ref _addrV2Regex;
+				}
+
 				for(; i < lines.Length; i++) {
 					if(lines[i].Length > 0) {
-						Match m = _addrRegex.Match(lines[i]);
+						Match m = regex.Match(lines[i]);
 						if(m.Success) {
-							int bank = Int32.Parse(m.Groups[1].Value, System.Globalization.NumberStyles.HexNumber);
-							int addr = (bank << 16) | Int32.Parse(m.Groups[2].Value, System.Globalization.NumberStyles.HexNumber);
+							int bank = Int32.Parse(m.Groups[bank_idx].Value, System.Globalization.NumberStyles.HexNumber);
+							int addr = (bank << 16) | Int32.Parse(m.Groups[addr_idx].Value, System.Globalization.NumberStyles.HexNumber);
 							
-							int fileId = Int32.Parse(m.Groups[3].Value, System.Globalization.NumberStyles.HexNumber);
-							int lineNumber = Int32.Parse(m.Groups[4].Value, System.Globalization.NumberStyles.HexNumber);
+							int fileId = Int32.Parse(m.Groups[field_idx].Value, System.Globalization.NumberStyles.HexNumber);
+							int lineNumber = Int32.Parse(m.Groups[line_idx].Value, System.Globalization.NumberStyles.HexNumber);
 
 							if(lineNumber <= 1) {
 								//Ignore line number 0 and 1, seems like bad data?


### PR DESCRIPTION
This syntax is a bit gnarly, and I am not entirely convinced that the WLA-DX V2 addr-to-line symbol mapping is actually correct in WLA-DX's repo. I agree with the concerns in the code that there are oddities to the Line 0 or Line 1 conversion.

See: https://github.com/vhelin/wla-dx/blob/800c3f8d332f4d1c2846c65e43b919af89de89f1/doc/symbols.rst