### PR TITLE
W.I.P port to the latest avalonia update

### DIFF
--- a/UI/App.axaml.cs
+++ b/UI/App.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Platform;
+using Avalonia.Input.Platform;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Mesen.Config;
@@ -18,6 +19,8 @@ namespace Mesen
 	public class App : Application
 	{
 		public static bool ShowConfigWindow { get; set; }
+		
+		public static IClipboard? Clipboard { get; set; }
 
 		public override void Initialize()
 		{

--- a/UI/Controls/EnumComboBox.axaml
+++ b/UI/Controls/EnumComboBox.axaml
@@ -12,7 +12,7 @@
 	<ComboBox
 		Name="Dropdown"
 		HorizontalAlignment="Stretch"
-		Items="{CompiledBinding InternalItems, ElementName=root}"
+		ItemsSource="{CompiledBinding InternalItems, ElementName=root}"
 		SelectedItem="{CompiledBinding InternalSelectedItem, ElementName=root}"
 	/>
 </UserControl>

--- a/UI/Controls/PaletteConfig.axaml
+++ b/UI/Controls/PaletteConfig.axaml
@@ -32,7 +32,7 @@
 				Click="btnSelectPalette_OnClick"
 			>
 				<Button.ContextMenu>
-					<ContextMenu Name="Preset" PlacementMode="Bottom" Items="{CompiledBinding PalettePresets, ElementName=root}">
+					<ContextMenu Name="Preset" PlacementMode="Bottom" ItemsSource="{CompiledBinding PalettePresets, ElementName=root}">
 						<ContextMenu.Styles>
 							<Style Selector="MenuItem">
 								<Setter Property="Header" Value="{Binding Name}" />

--- a/UI/Debugger/Controls/ActionToolbar.axaml
+++ b/UI/Debugger/Controls/ActionToolbar.axaml
@@ -35,7 +35,7 @@
 		</Style>
 	</UserControl.Styles>
 	
-	<ItemsControl DataContext="{Binding ElementName=root}" Items="{Binding Items}">
+	<ItemsControl DataContext="{Binding ElementName=root}" ItemsSource="{Binding Items}">
 		<ItemsControl.ItemsPanel>
 			<ItemsPanelTemplate>
 				<StackPanel Orientation="Horizontal" />
@@ -82,7 +82,7 @@
 						<ContextMenu
 							IsEnabled="{Binding SubActions, Converter={x:Static ObjectConverters.IsNotNull}}"
 							Name="ActionMenu"
-						  Items="{Binding SubActions}"
+							ItemsSource="{Binding SubActions}"
 						/>
 					</Button.ContextMenu>
 				</Button>

--- a/UI/Debugger/Controls/DebuggerShortcutKeyGrid.axaml
+++ b/UI/Debugger/Controls/DebuggerShortcutKeyGrid.axaml
@@ -27,7 +27,7 @@
 		</Border>
 		
 		<ScrollViewer AllowAutoHide="False">
-			<ItemsControl Items="{Binding Shortcuts}">
+			<ItemsControl ItemsSource="{Binding Shortcuts}">
 				<ItemsControl.ItemsPanel>
 					<ItemsPanelTemplate>
 						<VirtualizingStackPanel />

--- a/UI/Debugger/Controls/DisassemblyViewer.cs
+++ b/UI/Debugger/Controls/DisassemblyViewer.cs
@@ -20,7 +20,7 @@ namespace Mesen.Debugger.Controls
 
 		public static readonly StyledProperty<string> SearchStringProperty = AvaloniaProperty.Register<DisassemblyViewer, string>(nameof(SearchString), string.Empty);
 
-		public static readonly StyledProperty<FontFamily> FontFamilyProperty = AvaloniaProperty.Register<DisassemblyViewer, FontFamily>(nameof(FontFamily), new FontFamily(FontManager.Current.DefaultFontFamilyName));
+		public static readonly StyledProperty<FontFamily> FontFamilyProperty = AvaloniaProperty.Register<DisassemblyViewer, FontFamily>(nameof(FontFamily), FontManager.Current.DefaultFontFamily);
 		public static readonly StyledProperty<double> FontSizeProperty = AvaloniaProperty.Register<DisassemblyViewer, double>(nameof(FontSize), 12);
 		public static readonly StyledProperty<bool> ShowByteCodeProperty = AvaloniaProperty.Register<DisassemblyViewer, bool>(nameof(ShowByteCode), false);
 		public static readonly StyledProperty<AddressDisplayType> AddressDisplayTypeProperty = AvaloniaProperty.Register<DisassemblyViewer, AddressDisplayType>(nameof(AddressDisplayType), AddressDisplayType.CpuAddress);

--- a/UI/Debugger/Controls/DynamicTooltip.axaml
+++ b/UI/Debugger/Controls/DynamicTooltip.axaml
@@ -5,6 +5,7 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:l="using:Mesen.Localization"
 	xmlns:dc="using:Mesen.Debugger.Controls"
+	xmlns:system="clr-namespace:System;assembly=System.Runtime"
 	mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="50"
 	x:Name="root"
 	HorizontalAlignment="Stretch"
@@ -98,7 +99,7 @@
 								/>
 							</Border>
 						</DataTemplate>
-						<DataTemplate DataType="x:Array">
+						<DataTemplate DataType="system:Array">
 							<Border BorderBrush="Gray" BorderThickness="1" Margin="0 1" VerticalAlignment="Top">
 								<dc:PaletteSelector
 									PaletteColors="{Binding}"
@@ -114,5 +115,5 @@
 		</DataTemplate>
 	</UserControl.DataTemplates>
 	
-	<ItemsControl DataContext="{Binding, ElementName=root}" Items="{Binding Items}" />
+	<ItemsControl DataContext="{Binding, ElementName=root}" ItemsSource="{Binding Items}" />
 </UserControl>

--- a/UI/Debugger/Controls/HexEditor.cs
+++ b/UI/Debugger/Controls/HexEditor.cs
@@ -22,7 +22,7 @@ namespace Mesen.Debugger.Controls
 		public static readonly StyledProperty<int> SelectionStartProperty = AvaloniaProperty.Register<HexEditor, int>(nameof(SelectionStart), 0, defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
 		public static readonly StyledProperty<int> SelectionLengthProperty = AvaloniaProperty.Register<HexEditor, int>(nameof(SelectionLength), 0, defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
 
-		public static readonly StyledProperty<FontFamily> FontFamilyProperty = AvaloniaProperty.Register<HexEditor, FontFamily>(nameof(FontFamily), new FontFamily(FontManager.Current.DefaultFontFamilyName));
+		public static readonly StyledProperty<FontFamily> FontFamilyProperty = AvaloniaProperty.Register<HexEditor, FontFamily>(nameof(FontFamily), FontManager.Current.DefaultFontFamily);
 		public static readonly StyledProperty<double> FontSizeProperty = AvaloniaProperty.Register<HexEditor, double>(nameof(FontSize), 12);
 
 		public static readonly StyledProperty<bool> ShowStringViewProperty = AvaloniaProperty.Register<HexEditor, bool>(nameof(ShowStringView), false);
@@ -402,12 +402,12 @@ namespace Mesen.Debugger.Controls
 				}
 			}
 
-			Application.Current?.Clipboard?.SetTextAsync(sb.ToString());
+			TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(sb.ToString());
 		}
 
 		public async void PasteSelection()
 		{
-			var clipboard = Application.Current?.Clipboard;
+			var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
 			if(clipboard != null) {
 				string? text = await clipboard.GetTextAsync();
 				if(text != null) {

--- a/UI/Debugger/Utilities/HdPackCopyHelper.cs
+++ b/UI/Debugger/Utilities/HdPackCopyHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Controls;
 using Mesen.Interop;
 using System;
 using System.Collections.Generic;
@@ -70,7 +71,7 @@ namespace Mesen.Debugger.Utilities
 			}
 
 			if(hdPackTile.Length > 0) {
-				Application.Current?.Clipboard?.SetTextAsync(hdPackTile);
+				App.Clipboard?.SetTextAsync(hdPackTile);
 			}
 		}
 	}

--- a/UI/Debugger/ViewModels/DisassemblyViewModel.cs
+++ b/UI/Debugger/ViewModels/DisassemblyViewModel.cs
@@ -313,7 +313,7 @@ namespace Mesen.Debugger.ViewModels
 		{
 			DebuggerConfig cfg = Config.Debugger;
 			string code = GetSelection(cfg.CopyAddresses, cfg.CopyByteCode, cfg.CopyComments, cfg.CopyBlockHeaders, out _, false);
-			Application.Current?.Clipboard?.SetTextAsync(code);
+			App.Clipboard?.SetTextAsync(code);
 		}
 
 		public string GetSelection(bool getAddresses, bool getByteCode, bool getComments, bool getHeaders, out int byteCount, bool skipGeneratedJmpSubLabels)

--- a/UI/Debugger/ViewModels/SourceViewViewModel.cs
+++ b/UI/Debugger/ViewModels/SourceViewViewModel.cs
@@ -193,7 +193,7 @@ public class SourceViewViewModel : DisposableViewModel, ISelectableModel
 			for(int i = SelectionStart; i <= SelectionEnd; i++) {
 				sb.AppendLine(SelectedFile.Data[i]);
 			}
-			Application.Current?.Clipboard?.SetTextAsync(sb.ToString());
+			App.Clipboard?.SetTextAsync(sb.ToString());
 		}
 	}
 

--- a/UI/Debugger/ViewModels/TraceLoggerViewModel.cs
+++ b/UI/Debugger/ViewModels/TraceLoggerViewModel.cs
@@ -376,7 +376,7 @@ namespace Mesen.Debugger.ViewModels
 				string addrFormat = "X" + lines[i].CpuType.GetAddressSize();
 				sb.AppendLine(lines[i].GetAddressText(AddressDisplayType.CpuAddress, addrFormat).PadRight(6) + " " + lines[i].Text);
 			}
-			Application.Current?.Clipboard?.SetTextAsync(sb.ToString());
+			App.Clipboard?.SetTextAsync(sb.ToString());
 		}
 
 		private bool IsRowVisible(int rowNumber)

--- a/UI/Debugger/Views/BreakpointListView.axaml
+++ b/UI/Debugger/Views/BreakpointListView.axaml
@@ -19,7 +19,7 @@
 
 	<Border BorderThickness="0 1 0 0" BorderBrush="{StaticResource MesenGrayBorderColor}">
 		<DataBox
-			Items="{CompiledBinding Breakpoints}"
+			ItemsSource="{CompiledBinding Breakpoints}"
 			Selection="{CompiledBinding Selection}"
 			CellClick="OnCellClick"
 			CellDoubleClick="OnCellDoubleClick"

--- a/UI/Debugger/Views/CallStackView.axaml
+++ b/UI/Debugger/Views/CallStackView.axaml
@@ -26,7 +26,7 @@
 
 	<Border BorderThickness="0 1 0 0" BorderBrush="{StaticResource MesenGrayBorderColor}">
 		<DataBox
-			Items="{CompiledBinding CallStackContent}"
+			ItemsSource="{CompiledBinding CallStackContent}"
 			Selection="{CompiledBinding Selection}"
 			GridLinesVisibility="All"
 			CellDoubleClick="OnCellDoubleClick"

--- a/UI/Debugger/Views/ControllerListView.axaml
+++ b/UI/Debugger/Views/ControllerListView.axaml
@@ -18,7 +18,7 @@
 	</Design.DataContext>
 
 	<ScrollViewer AllowAutoHide="False">
-		<ItemsControl Items="{CompiledBinding Controllers}" VerticalAlignment="Center">
+		<ItemsControl ItemsSource="{CompiledBinding Controllers}" VerticalAlignment="Center">
 			<ItemsControl.ItemsPanel>
 				<ItemsPanelTemplate>
 					<WrapPanel />

--- a/UI/Debugger/Views/FindResultListView.axaml
+++ b/UI/Debugger/Views/FindResultListView.axaml
@@ -19,7 +19,7 @@
 
 	<Border BorderThickness="0 1 0 0" BorderBrush="{StaticResource MesenGrayBorderColor}">
 		<DataBox
-			Items="{CompiledBinding FindResults}"
+			ItemsSource="{CompiledBinding FindResults}"
 			Selection="{CompiledBinding Selection}"
 			CellDoubleClick="OnCellDoubleClick"
 			SelectionMode="Single"

--- a/UI/Debugger/Views/FunctionListView.axaml
+++ b/UI/Debugger/Views/FunctionListView.axaml
@@ -27,7 +27,7 @@
 
 	<Border BorderThickness="0 1 0 0" BorderBrush="{StaticResource MesenGrayBorderColor}">
 		<DataBox
-			Items="{CompiledBinding Functions}"
+			ItemsSource="{CompiledBinding Functions}"
 			Selection="{CompiledBinding Selection}"
 			GridLinesVisibility="All"
 			SelectionMode="Multiple"

--- a/UI/Debugger/Views/LabelListView.axaml
+++ b/UI/Debugger/Views/LabelListView.axaml
@@ -33,7 +33,7 @@
 
 	<Border BorderThickness="0 1 0 0" BorderBrush="#80808080">
 		<DataBox
-			Items="{CompiledBinding Labels}"
+			ItemsSource="{CompiledBinding Labels}"
 			Selection="{CompiledBinding Selection}"
 			GridLinesVisibility="All"
 			SelectionMode="Multiple"

--- a/UI/Debugger/Views/MemoryToolsDisplayOptionsView.axaml
+++ b/UI/Debugger/Views/MemoryToolsDisplayOptionsView.axaml
@@ -126,7 +126,7 @@
 				<TextBlock DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center">Columns: </TextBlock>
 				<ComboBox
 					SelectedItem="{CompiledBinding Config.BytesPerRow}"
-					Items="{CompiledBinding AvailableWidths}"
+					ItemsSource="{CompiledBinding AvailableWidths}"
 				/>
 			</StackPanel>
 			<CheckBox

--- a/UI/Debugger/Views/RegisterTabView.axaml
+++ b/UI/Debugger/Views/RegisterTabView.axaml
@@ -21,7 +21,7 @@
 	<Border BorderBrush="{StaticResource MesenGrayBorderColor}" BorderThickness="1">
 		<DataBox
 			Name="lstRegisterTab"
-			Items="{CompiledBinding Data}"
+			ItemsSource="{CompiledBinding Data}"
 			Selection="{CompiledBinding Selection}"
 			GridLinesVisibility="All"
 			ColumnWidths="{CompiledBinding ColumnWidths}"

--- a/UI/Debugger/Views/ScriptCodeCompletionView.axaml
+++ b/UI/Debugger/Views/ScriptCodeCompletionView.axaml
@@ -36,21 +36,21 @@
 
 			<TextBlock Text="Parameters" TextDecorations="Underline" Margin="0 10 0 0" />
 			<Grid IsVisible="{CompiledBinding Parameters.Count}" ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto" Margin="5 3 0 0" >
-				<ItemsControl Items="{CompiledBinding Parameters}" Grid.Column="0">
+				<ItemsControl ItemsSource="{CompiledBinding Parameters}" Grid.Column="0">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
 							<TextBlock Text="{CompiledBinding Name}" FontWeight="Bold" Padding="2 0" />
 						</DataTemplate>
 					</ItemsControl.ItemTemplate>
 				</ItemsControl>
-				<ItemsControl Items="{CompiledBinding Parameters}" Grid.Column="1">
+				<ItemsControl ItemsSource="{CompiledBinding Parameters}" Grid.Column="1">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
 							<TextBlock Text="{CompiledBinding CalculatedType}" FontStyle="Italic" Margin="5 0" Padding="5 0" />
 						</DataTemplate>
 					</ItemsControl.ItemTemplate>
 				</ItemsControl>
-				<ItemsControl Items="{CompiledBinding Parameters}" Grid.Column="2">
+				<ItemsControl ItemsSource="{CompiledBinding Parameters}" Grid.Column="2">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
 							<StackPanel Orientation="Horizontal">
@@ -76,14 +76,14 @@
 		<StackPanel IsVisible="{CompiledBinding EnumValues.Count}">
 			<TextBlock Text="Values" TextDecorations="Underline" Margin="0 10 0 0" />
 			<Grid IsVisible="{CompiledBinding EnumValues.Count}" ColumnDefinitions="Auto,Auto" RowDefinitions="Auto" Margin="5 3 0 0" >
-				<ItemsControl Items="{CompiledBinding EnumValues}" Grid.Column="0">
+				<ItemsControl ItemsSource="{CompiledBinding EnumValues}" Grid.Column="0">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
 							<TextBlock Text="{CompiledBinding Name}" FontWeight="Bold" Padding="2 0" />
 						</DataTemplate>
 					</ItemsControl.ItemTemplate>
 				</ItemsControl>
-				<ItemsControl Items="{CompiledBinding EnumValues}" Grid.Column="1">
+				<ItemsControl ItemsSource="{CompiledBinding EnumValues}" Grid.Column="1">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
 							<TextBlock Text="{CompiledBinding Description}" Padding="5 0" />

--- a/UI/Debugger/Views/SourceViewView.axaml
+++ b/UI/Debugger/Views/SourceViewView.axaml
@@ -21,7 +21,7 @@
 	<DockPanel>
 		<DockPanel DockPanel.Dock="Top" Margin="2">
 			<TextBlock Text="{l:Translate lblFile}" VerticalAlignment="Center" DockPanel.Dock="Left" Margin="3 0" />
-			<ComboBox Items="{CompiledBinding SourceFiles}" SelectedItem="{CompiledBinding SelectedFile}" HorizontalAlignment="Stretch" />
+			<ComboBox ItemsSource="{CompiledBinding SourceFiles}" SelectedItem="{CompiledBinding SelectedFile}" HorizontalAlignment="Stretch" />
 		</DockPanel>
 
 		<Border BorderBrush="{StaticResource MesenGrayBorderColor}" BorderThickness="0 1 0 0">

--- a/UI/Debugger/Views/WatchListView.axaml
+++ b/UI/Debugger/Views/WatchListView.axaml
@@ -52,7 +52,7 @@
 	<Border BorderThickness="0 1 0 0" BorderBrush="{StaticResource MesenGrayBorderColor}">
 		<DataBox
 			Name="WatchList"
-			Items="{CompiledBinding WatchEntries}"
+			ItemsSource="{CompiledBinding WatchEntries}"
 			Selection="{CompiledBinding Selection}"
 			SelectionMode="Multiple"
 			GridLinesVisibility="All"

--- a/UI/Debugger/Windows/AssemblerWindow.axaml
+++ b/UI/Debugger/Windows/AssemblerWindow.axaml
@@ -34,8 +34,8 @@
 
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-			<MenuItem Header="{l:Translate mnuOptions}" Items="{CompiledBinding OptionsMenuActions}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+			<MenuItem Header="{l:Translate mnuOptions}" ItemsSource="{CompiledBinding OptionsMenuActions}" />
 		</c:MesenMenu>
 		
 		<Grid Classes="main" ColumnDefinitions="1*, 300" RowDefinitions="3*,100" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
@@ -61,7 +61,7 @@
 
 			<Border Grid.Row="1">
 				<DataBox
-					Items="{CompiledBinding Errors}"
+					ItemsSource="{CompiledBinding Errors}"
 					GridLinesVisibility="All"
 					CellClick="OnCellClick"
 				>

--- a/UI/Debugger/Windows/DebuggerWindow.axaml
+++ b/UI/Debugger/Windows/DebuggerWindow.axaml
@@ -61,10 +61,10 @@
 	
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuItems}" />
-			<MenuItem Header="{l:Translate mnuDebug}" Items="{CompiledBinding DebugMenuItems}" />
-			<MenuItem Header="{l:Translate mnuSearch}" Items="{CompiledBinding SearchMenuItems}" />
-			<MenuItem Header="{l:Translate mnuOptions}" Items="{CompiledBinding OptionMenuItems}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuItems}" />
+			<MenuItem Header="{l:Translate mnuDebug}" ItemsSource="{CompiledBinding DebugMenuItems}" />
+			<MenuItem Header="{l:Translate mnuSearch}" ItemsSource="{CompiledBinding SearchMenuItems}" />
+			<MenuItem Header="{l:Translate mnuOptions}" ItemsSource="{CompiledBinding OptionMenuItems}" />
 		</c:MesenMenu>
 		<DockPanel DockPanel.Dock="Top">
 			<c:IconButton

--- a/UI/Debugger/Windows/EventViewerWindow.axaml
+++ b/UI/Debugger/Windows/EventViewerWindow.axaml
@@ -49,9 +49,9 @@
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-				<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuItems}" />
-				<MenuItem Header="{l:Translate mnuDebug}" Items="{CompiledBinding DebugMenuItems}" />
-				<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuItems}" />
+				<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuItems}" />
+				<MenuItem Header="{l:Translate mnuDebug}" ItemsSource="{CompiledBinding DebugMenuItems}" />
+				<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuItems}" />
 			</c:MesenMenu>
 			<c:IconButton
 				HorizontalAlignment="Right"
@@ -109,7 +109,7 @@
 			<Border BorderBrush="Gray" BorderThickness="1" Grid.Row="2">
 				<DataBox
 					Name="lstEvents"
-					Items="{CompiledBinding ListView.DebugEvents}"
+					ItemsSource="{CompiledBinding ListView.DebugEvents}"
 					Selection="{CompiledBinding ListView.Selection}"
 					SortMode="Multiple"
 					SortCommand="{CompiledBinding ListView.SortCommand}"

--- a/UI/Debugger/Windows/GoToAllWindow.axaml
+++ b/UI/Debugger/Windows/GoToAllWindow.axaml
@@ -72,7 +72,7 @@
 			<ListBox
 				Name="lstResults"
 				Background="Transparent"
-				Items="{CompiledBinding SearchResults}"
+				ItemsSource="{CompiledBinding SearchResults}"
 				Selection="{CompiledBinding SelectionModel}"
 				ScrollViewer.AllowAutoHide="False"
 			>

--- a/UI/Debugger/Windows/MemorySearchWindow.axaml
+++ b/UI/Debugger/Windows/MemorySearchWindow.axaml
@@ -163,7 +163,7 @@
 
 		<Border BorderBrush="Gray" BorderThickness="1">
 			<DataBox
-				Items="{Binding ListData}"
+				ItemsSource="{Binding ListData}"
 				Selection="{Binding Selection}"
 				SortState="{Binding SortState}"
 				SortMode="Multiple"

--- a/UI/Debugger/Windows/MemoryToolsWindow.axaml
+++ b/UI/Debugger/Windows/MemoryToolsWindow.axaml
@@ -32,9 +32,9 @@
 
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuItems}" />
-			<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuItems}" />
-			<MenuItem Header="{l:Translate mnuSearch}" Items="{CompiledBinding SearchMenuItems}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuItems}" />
+			<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuItems}" />
+			<MenuItem Header="{l:Translate mnuSearch}" ItemsSource="{CompiledBinding SearchMenuItems}" />
 		</c:MesenMenu>
 		<DockPanel DockPanel.Dock="Top" Margin="3 2">
 			<StackPanel Orientation="Horizontal" DockPanel.Dock="Left">

--- a/UI/Debugger/Windows/PaletteViewerWindow.axaml
+++ b/UI/Debugger/Windows/PaletteViewerWindow.axaml
@@ -26,8 +26,8 @@
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-				<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-				<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuActions}" />
+				<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+				<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuActions}" />
 			</c:MesenMenu>
 			<c:IconButton
 				HorizontalAlignment="Right"

--- a/UI/Debugger/Windows/ProfilerWindow.axaml
+++ b/UI/Debugger/Windows/ProfilerWindow.axaml
@@ -30,7 +30,7 @@
 		</Style>
 	</Window.Styles>
 
-	<TabControl Items="{CompiledBinding ProfilerTabs}" SelectedItem="{CompiledBinding SelectedTab}" Padding="1">
+	<TabControl ItemsSource="{CompiledBinding ProfilerTabs}" SelectedItem="{CompiledBinding SelectedTab}" Padding="1">
 		<TabControl.ItemTemplate>
 			<DataTemplate>
 				<TextBlock Text="{Binding TabName}" />
@@ -49,7 +49,7 @@
 
 					<Border BorderBrush="Gray" BorderThickness="1">
 						<DataBox
-							Items="{Binding GridData}"
+							ItemsSource="{Binding GridData}"
 							Selection="{Binding Selection}"
 							SortState="{Binding SortState}"
 							CellDoubleClick="OnCellDoubleClick"

--- a/UI/Debugger/Windows/RegisterViewerWindow.axaml
+++ b/UI/Debugger/Windows/RegisterViewerWindow.axaml
@@ -32,13 +32,13 @@
 
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-			<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuActions}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+			<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuActions}" />
 		</c:MesenMenu>
 
 		<dv:RefreshTimingView DataContext="{CompiledBinding RefreshTiming}" DockPanel.Dock="Bottom" />
 		
-		<TabControl Items="{CompiledBinding Tabs}" Padding="1">
+		<TabControl ItemsSource="{CompiledBinding Tabs}" Padding="1">
 			<TabControl.ItemTemplate>
 				<DataTemplate>
 					<TextBlock Text="{Binding TabName}" />

--- a/UI/Debugger/Windows/ScriptWindow.axaml
+++ b/UI/Debugger/Windows/ScriptWindow.axaml
@@ -31,9 +31,9 @@
 
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-			<MenuItem Header="{l:Translate mnuScript}" Items="{CompiledBinding ScriptMenuActions}" />
-			<MenuItem Header="{l:Translate mnuHelp}" Items="{CompiledBinding HelpMenuActions}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+			<MenuItem Header="{l:Translate mnuScript}" ItemsSource="{CompiledBinding ScriptMenuActions}" />
+			<MenuItem Header="{l:Translate mnuHelp}" ItemsSource="{CompiledBinding HelpMenuActions}" />
 		</c:MesenMenu>
 
 		<StackPanel Orientation="Horizontal" DockPanel.Dock="Top">

--- a/UI/Debugger/Windows/SpriteViewerWindow.axaml
+++ b/UI/Debugger/Windows/SpriteViewerWindow.axaml
@@ -36,8 +36,8 @@
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-				<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-				<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuActions}" />
+				<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+				<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuActions}" />
 			</c:MesenMenu>
 			<c:IconButton
 				HorizontalAlignment="Right"
@@ -134,7 +134,7 @@
 			<Border BorderBrush="Gray" BorderThickness="1" Grid.Row="2" Margin="1" Grid.ColumnSpan="2">
 				<DataBox
 					Name="ListView"
-					Items="{CompiledBinding ListView.SpritePreviews}"
+					ItemsSource="{CompiledBinding ListView.SpritePreviews}"
 					Selection="{CompiledBinding ListView.Selection}"
 					CanUserResizeColumns="False"
 					SortMode="Multiple"

--- a/UI/Debugger/Windows/TileEditorWindow.axaml
+++ b/UI/Debugger/Windows/TileEditorWindow.axaml
@@ -27,9 +27,9 @@
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-				<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-				<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuActions}" />
-				<MenuItem Header="{l:Translate mnuTools}" Items="{CompiledBinding ToolsMenuActions}" />
+				<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+				<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuActions}" />
+				<MenuItem Header="{l:Translate mnuTools}" ItemsSource="{CompiledBinding ToolsMenuActions}" />
 			</c:MesenMenu>
 		</Panel>
 

--- a/UI/Debugger/Windows/TileViewerWindow.axaml
+++ b/UI/Debugger/Windows/TileViewerWindow.axaml
@@ -45,8 +45,8 @@
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-				<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-				<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuActions}" />
+				<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+				<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuActions}" />
 			</c:MesenMenu>
 			<c:IconButton
 				HorizontalAlignment="Right"
@@ -64,10 +64,10 @@
 				<Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 					<TextBlock Text="{l:Translate lblPresets}" Margin="0 5 0 0 " VerticalAlignment="Top" />
 					<Panel Grid.Column="1" MaxWidth="160" HorizontalAlignment="Left">
-						<ItemsControl Items="{CompiledBinding ConfigPresetRows}">
+						<ItemsControl ItemsSource="{CompiledBinding ConfigPresetRows}">
 							<ItemsControl.ItemTemplate>
 								<DataTemplate>
-									<ItemsControl Items="{Binding}">
+									<ItemsControl ItemsSource="{Binding}">
 										<ItemsControl.ItemsPanel>
 											<ItemsPanelTemplate>
 												<WrapPanel />

--- a/UI/Debugger/Windows/TilemapViewerWindow.axaml
+++ b/UI/Debugger/Windows/TilemapViewerWindow.axaml
@@ -33,8 +33,8 @@
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-				<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuActions}" />
-				<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuActions}" />
+				<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuActions}" />
+				<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuActions}" />
 			</c:MesenMenu>
 			<c:IconButton
 				HorizontalAlignment="Right"
@@ -86,7 +86,7 @@
 		</ScrollViewer>
 
 		<TabControl
-			Items="{CompiledBinding Tabs}"
+			ItemsSource="{CompiledBinding Tabs}"
 			SelectedItem="{CompiledBinding SelectedTab}"
 			IsVisible="{CompiledBinding ShowTabs}"
 			Padding="1"

--- a/UI/Debugger/Windows/TraceLoggerWindow.axaml
+++ b/UI/Debugger/Windows/TraceLoggerWindow.axaml
@@ -36,10 +36,10 @@
 
 	<DockPanel Margin="2">
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuItems}" />
-			<MenuItem Header="{l:Translate mnuDebug}" Items="{CompiledBinding DebugMenuItems}" />
-			<MenuItem Header="{l:Translate mnuSearch}" Items="{CompiledBinding SearchMenuItems}" />
-			<MenuItem Header="{l:Translate mnuView}" Items="{CompiledBinding ViewMenuItems}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuItems}" />
+			<MenuItem Header="{l:Translate mnuDebug}" ItemsSource="{CompiledBinding DebugMenuItems}" />
+			<MenuItem Header="{l:Translate mnuSearch}" ItemsSource="{CompiledBinding SearchMenuItems}" />
+			<MenuItem Header="{l:Translate mnuView}" ItemsSource="{CompiledBinding ViewMenuItems}" />
 		</c:MesenMenu>
 
 		<StackPanel Orientation="Horizontal" DockPanel.Dock="Top" IsVisible="{CompiledBinding Config.ShowToolbar}">
@@ -78,7 +78,7 @@
 			/>
 		</Grid>
 		
-		<TabControl Items="{CompiledBinding Tabs}" SelectedItem="{CompiledBinding SelectedTab}" Padding="1" DockPanel.Dock="Bottom">
+		<TabControl ItemsSource="{CompiledBinding Tabs}" SelectedItem="{CompiledBinding SelectedTab}" Padding="1" DockPanel.Dock="Bottom">
 			<TabControl.ItemTemplate>
 				<DataTemplate>
 					<StackPanel Orientation="Horizontal">

--- a/UI/Debugger/Windows/WatchWindow.axaml
+++ b/UI/Debugger/Windows/WatchWindow.axaml
@@ -32,7 +32,7 @@
 	</Window.Styles>
 	
 	<Panel>
-		<TabControl Items="{CompiledBinding WatchTabs}" SelectedItem="{CompiledBinding SelectedTab}" Padding="1">
+		<TabControl ItemsSource="{CompiledBinding WatchTabs}" SelectedItem="{CompiledBinding SelectedTab}" Padding="1">
 			<TabControl.ItemTemplate>
 				<DataTemplate>
 					<TextBlock Text="{Binding TabName}" />

--- a/UI/Interop/EmuApi.cs
+++ b/UI/Interop/EmuApi.cs
@@ -15,7 +15,7 @@ namespace Mesen.Interop
 {
 	public class EmuApi
 	{
-		public const string DllName = "MesenCore.dll";
+		public const string DllName = "MesenCore.dylib";
 		private const string DllPath = EmuApi.DllName;
 
 		[DllImport(DllPath)] [return: MarshalAs(UnmanagedType.I1)] public static extern bool TestDll();

--- a/UI/Styles/AvaloniaScrollViewerStyles.xaml
+++ b/UI/Styles/AvaloniaScrollViewerStyles.xaml
@@ -17,8 +17,8 @@
 													Grid.RowSpan="1"
 													Grid.ColumnSpan="1"
 													Background="{TemplateBinding Background}"
-													CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"
-													CanVerticallyScroll="{TemplateBinding CanVerticallyScroll}"
+													CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+													CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
 													Content="{TemplateBinding Content}"
 													Extent="{TemplateBinding Extent, Mode=TwoWay}"
 													Margin="{TemplateBinding Padding}"
@@ -26,29 +26,29 @@
 													Viewport="{TemplateBinding Viewport, Mode=TwoWay}">
 						<ScrollContentPresenter.GestureRecognizers>
 							<ScrollGestureRecognizer
-							  CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"
-							  CanVerticallyScroll="{TemplateBinding CanVerticallyScroll}" />
+							  CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+							  CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}" />
 						</ScrollContentPresenter.GestureRecognizers>
 					</c:MesenScrollContentPresenter>
+					<!-- Maximum="{TemplateBinding HorizontalScrollBarMaximum}" -->
+					<!-- Value="{TemplateBinding HorizontalScrollBarValue, Mode=TwoWay}" -->
+					<!-- ViewportSize="{TemplateBinding HorizontalScrollBarViewportSize}" -->
 					<ScrollBar Name="PART_HorizontalScrollBar"
-								  AllowAutoHide="{TemplateBinding AllowAutoHide}"
-								  Orientation="Horizontal"
-								  LargeChange="{Binding LargeChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
-								  SmallChange="{Binding SmallChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
-								  Maximum="{TemplateBinding HorizontalScrollBarMaximum}"
-								  Value="{TemplateBinding HorizontalScrollBarValue, Mode=TwoWay}"
-								  ViewportSize="{TemplateBinding HorizontalScrollBarViewportSize}"
-								  Visibility="{TemplateBinding HorizontalScrollBarVisibility}"
-								  Grid.Row="1"
-								  Focusable="False" />
+					           AllowAutoHide="{TemplateBinding AllowAutoHide}"
+					           Orientation="Horizontal"
+					           LargeChange="{Binding LargeChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
+					           SmallChange="{Binding SmallChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
+					           Visibility="{TemplateBinding HorizontalScrollBarVisibility}"
+					           Grid.Row="1"
+					           Focusable="False" />
+					<!-- Maximum="{TemplateBinding VerticalScrollBarMaximum}" -->
+					<!-- Value="{TemplateBinding VerticalScrollBarValue, Mode=TwoWay}" -->
+					<!-- ViewportSize="{TemplateBinding VerticalScrollBarViewportSize}" -->
 					<ScrollBar Name="PART_VerticalScrollBar"
 								  AllowAutoHide="{TemplateBinding AllowAutoHide}"
 								  Orientation="Vertical"
 								  LargeChange="{Binding LargeChange.Height, RelativeSource={RelativeSource TemplatedParent}}"
 								  SmallChange="{Binding SmallChange.Height, RelativeSource={RelativeSource TemplatedParent}}"
-								  Maximum="{TemplateBinding VerticalScrollBarMaximum}"
-								  Value="{TemplateBinding VerticalScrollBarValue, Mode=TwoWay}"
-								  ViewportSize="{TemplateBinding VerticalScrollBarViewportSize}"
 								  Visibility="{TemplateBinding VerticalScrollBarVisibility}"
 								  Grid.Column="1"
 								  Focusable="False" />

--- a/UI/Styles/MesenStyles.xaml
+++ b/UI/Styles/MesenStyles.xaml
@@ -156,7 +156,7 @@
 		<Setter Property="IsVisible" Value="{Binding Visible}" />
 		<Setter Property="IsEnabled" Value="{Binding Enabled}" />
 		<Setter Property="Tag" Value="{Binding ShortcutText}" />
-		<Setter Property="Items" Value="{Binding SubActions}" />
+		<Setter Property="ItemsSource" Value="{Binding SubActions}" />
 		<Setter Property="Command" Value="{Binding ClickCommand}" />
 	</Style>
 	

--- a/UI/ThirdParty/DataBox/DataBox.cs
+++ b/UI/ThirdParty/DataBox/DataBox.cs
@@ -25,12 +25,12 @@ namespace DataBoxControl;
 
 public class DataBox : TemplatedControl
 {
-    public static readonly DirectProperty<DataBox, IEnumerable?> ItemsProperty =
+    public static readonly DirectProperty<DataBox, IEnumerable?> ItemsSourceProperty =
 		  AvaloniaProperty.RegisterDirect<DataBox, IEnumerable?>(
-			  nameof(Items),
-            o => o.Items, 
+			  nameof(ItemsSource),
+            o => o.ItemsSource, 
             (o, v) => {
-					o.Items = v;
+					o.ItemsSource = v;
 					if(o.Selection != null) {
 						o.Selection.Source = v;
 					}
@@ -41,7 +41,7 @@ public class DataBox : TemplatedControl
 		  o => o.Selection,
 		  (o, v) => {
 			  if(v != null) {
-				  v.Source = o.Items;
+				  v.Source = o.ItemsSource;
 			     o.Selection = v;
 			  }
 		  },
@@ -97,10 +97,10 @@ public class DataBox : TemplatedControl
     }
 
     [Content]
-    public IEnumerable? Items
+    public IEnumerable? ItemsSource
     {
         get { return _items; }
-        set { SetAndRaise(ItemsProperty, ref _items, value); }
+        set { SetAndRaise(ItemsSourceProperty, ref _items, value); }
     }
 
 	public ISelectionModel Selection
@@ -231,7 +231,7 @@ public class DataBox : TemplatedControl
         {
             _rowsPresenter.DataBox = this;
 
-            _rowsPresenter[!!ItemsControl.ItemsProperty] = this[!!ItemsProperty];
+            _rowsPresenter[!!ItemsControl.ItemsSourceProperty] = this[!!ItemsSourceProperty];
             _rowsPresenter[!!ListBox.SelectionProperty] = this[!!SelectionProperty];
 
             _rowsPresenter.TemplateApplied += (_, _) =>
@@ -318,7 +318,7 @@ public class DataBox : TemplatedControl
 
 	private void ProcessKeyPress(string keyText)
 	{
-		if(Items == null || _rowsPresenter == null) {
+		if(ItemsSource == null || _rowsPresenter == null) {
 			return;
 		}
 
@@ -346,13 +346,13 @@ public class DataBox : TemplatedControl
 
 	private bool SearchColumn(DataBoxColumn column)
 	{
-		if(Items == null || _rowsPresenter == null) {
+		if(ItemsSource == null || _rowsPresenter == null) {
 			return false;
 		}
 
 		if(column is DataBoxTextColumn textColumn && textColumn.Binding is Binding columnBinding) {
 			Binding binding = new Binding(columnBinding.Path, BindingMode.OneTime);
-			foreach(object item in Items) {
+			foreach(object item in ItemsSource) {
 				binding.Source = item;
 				ValueGetter getter = new ValueGetter();
 				getter.Bind(ValueGetter.ValueProperty, binding);

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <AssemblyName>Mesen</AssemblyName>
@@ -82,12 +82,12 @@
 	  <None Remove="Utilities\DipSwitchDefinitions.xml" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview7" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview7" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview7" />
     <PackageReference Include="Dock.Avalonia" Version="11.0.0-preview6" />
     <PackageReference Include="Dock.Model.Avalonia" Version="11.0.0-preview6" />
     <PackageReference Include="Dock.Model.ReactiveUI" Version="11.0.0-preview6" />

--- a/UI/Utilities/GlobalMouseLib/GlobalMouseX11Impl.cs
+++ b/UI/Utilities/GlobalMouseLib/GlobalMouseX11Impl.cs
@@ -11,7 +11,7 @@ public class GlobalMouseX11Impl : IGlobalMouseImpl
 
 	public GlobalMouseX11Impl()
 	{
-		_mainWindow = ApplicationHelper.GetMainWindow()?.PlatformImpl?.Handle.Handle ?? IntPtr.Zero;
+		_mainWindow = ApplicationHelper.GetMainWindow()?.TryGetPlatformHandle()?.Handle ?? IntPtr.Zero;
 		_x11 = new X11Info();
 	}
 

--- a/UI/Views/AudioConfigView.axaml
+++ b/UI/Views/AudioConfigView.axaml
@@ -44,7 +44,7 @@
 								Name="AudioDevice"
 								Grid.Row="0"
 								Grid.Column="1"
-								Items="{CompiledBinding AudioDevices}"
+								ItemsSource="{CompiledBinding AudioDevices}"
 								SelectedItem="{CompiledBinding Config.AudioDevice}"
 								Width="200"
 							/>

--- a/UI/Views/DefaultControllerView.axaml
+++ b/UI/Views/DefaultControllerView.axaml
@@ -17,7 +17,7 @@
 
 	<Border MaxWidth="500" MaxHeight="300" BorderBrush="Gray" BorderThickness="1" Margin="5">
 		<ScrollViewer>
-			<ItemsControl Items="{CompiledBinding CustomKeys}">
+			<ItemsControl ItemsSource="{CompiledBinding CustomKeys}">
 				<ItemsControl.ItemTemplate>
 					<DataTemplate>
 						<StackPanel>

--- a/UI/Views/MainMenuView.axaml
+++ b/UI/Views/MainMenuView.axaml
@@ -17,11 +17,11 @@
 	</Design.DataContext>
 
 	<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-		<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuItems}" />
-		<MenuItem Header="{l:Translate mnuGame}" Items="{CompiledBinding GameMenuItems}" />
-		<MenuItem Header="{l:Translate mnuOptions}" Items="{CompiledBinding OptionsMenuItems}" />
-		<MenuItem Header="{l:Translate mnuTools}" Items="{CompiledBinding ToolsMenuItems}" SubmenuOpened="mnuTools_Opened" />
-		<MenuItem Header="{l:Translate mnuDebug}" Items="{CompiledBinding DebugMenuItems}" />
-		<MenuItem Header="{l:Translate mnuHelp}" Items="{CompiledBinding HelpMenuItems}" />
+		<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuItems}" />
+		<MenuItem Header="{l:Translate mnuGame}" ItemsSource="{CompiledBinding GameMenuItems}" />
+		<MenuItem Header="{l:Translate mnuOptions}" ItemsSource="{CompiledBinding OptionsMenuItems}" />
+		<MenuItem Header="{l:Translate mnuTools}" ItemsSource="{CompiledBinding ToolsMenuItems}" SubmenuOpened="mnuTools_Opened" />
+		<MenuItem Header="{l:Translate mnuDebug}" ItemsSource="{CompiledBinding DebugMenuItems}" />
+		<MenuItem Header="{l:Translate mnuHelp}" ItemsSource="{CompiledBinding HelpMenuItems}" />
 	</c:MesenMenu>
 </UserControl>

--- a/UI/Views/ShortcutKeysTabView.axaml
+++ b/UI/Views/ShortcutKeysTabView.axaml
@@ -31,7 +31,7 @@
 		</Border>
 		
 		<ScrollViewer AllowAutoHide="False">
-			<ItemsControl Items="{Binding ShortcutKeys}">
+			<ItemsControl ItemsSource="{Binding ShortcutKeys}">
 				<ItemsControl.ItemTemplate>
 					<DataTemplate>
 						<StackPanel>

--- a/UI/Views/VideoConfigView.axaml
+++ b/UI/Views/VideoConfigView.axaml
@@ -64,14 +64,14 @@
 									<ComboBox
 										Grid.Row="1" Grid.Column="1"
 										SelectedItem="{CompiledBinding Config.ExclusiveFullscreenRefreshRateNtsc}"
-										Items="{CompiledBinding AvailableRefreshRates}"
+										ItemsSource="{CompiledBinding AvailableRefreshRates}"
 									/>
 
 									<TextBlock Grid.Row="2" Grid.Column="0" Text="{l:Translate lblRequestedRefreshRatePal}" />
 									<ComboBox
 										Grid.Row="2" Grid.Column="1"
 										SelectedItem="{CompiledBinding Config.ExclusiveFullscreenRefreshRatePal}"
-										Items="{CompiledBinding AvailableRefreshRates}"
+										ItemsSource="{CompiledBinding AvailableRefreshRates}"
 									/>
 								</Grid>
 							</StackPanel>

--- a/UI/Windows/AboutWindow.axaml
+++ b/UI/Windows/AboutWindow.axaml
@@ -88,7 +88,7 @@
 					<TextBlock Text="{l:Translate lblAcknowledgeList}" Margin="0 5 0 5" TextWrapping="Wrap" />
 					<Border BorderBrush="Gray" BorderThickness="1">
 						<ListBox
-							Items="{CompiledBinding AcknowledgeList, ElementName=root}"
+							ItemsSource="{CompiledBinding AcknowledgeList, ElementName=root}"
 							Background="Transparent"
 							ScrollViewer.AllowAutoHide="False"
 						/>
@@ -99,7 +99,7 @@
 					<TextBlock Text="{l:Translate lblUsedSoftware}" Margin="0 15 0 5" />
 					<Border BorderBrush="Gray" BorderThickness="1">
 						<ListBox
-							Items="{CompiledBinding LibraryList, ElementName=root}"
+							ItemsSource="{CompiledBinding LibraryList, ElementName=root}"
 							Height="130"
 							Background="Transparent"
 							ScrollViewer.AllowAutoHide="False"

--- a/UI/Windows/CheatDatabaseWindow.axaml
+++ b/UI/Windows/CheatDatabaseWindow.axaml
@@ -35,7 +35,7 @@
 		<Border BorderThickness="1" BorderBrush="{StaticResource MesenGrayBorderColor}" Margin="2">
 			<ListBox
 				Name="ListBox"
-				Items="{CompiledBinding FilteredEntries}"
+				ItemsSource="{CompiledBinding FilteredEntries}"
 				Selection="{CompiledBinding SelectionModel}"
 				DoubleTapped="OnDoubleTapped"
 				PointerReleased="OnPointerReleased"

--- a/UI/Windows/CheatListWindow.axaml
+++ b/UI/Windows/CheatListWindow.axaml
@@ -36,7 +36,7 @@
 		
 		<Border BorderThickness="1" BorderBrush="{StaticResource MesenGrayBorderColor}" Margin="2">
 			<DataBox
-				Items="{CompiledBinding Cheats}"
+				ItemsSource="{CompiledBinding Cheats}"
 				Selection="{CompiledBinding Selection}"
 				CellClick="OnCellClick"
 				CellDoubleClick="OnCellDoubleClick"

--- a/UI/Windows/CommandLineHelpWindow.axaml
+++ b/UI/Windows/CommandLineHelpWindow.axaml
@@ -30,7 +30,7 @@
 			/>
 		</StackPanel>
 
-		<TabControl Items="{CompiledBinding HelpTabs, ElementName=root}">
+		<TabControl ItemsSource="{CompiledBinding HelpTabs, ElementName=root}">
 			<TabControl.ItemTemplate>
 				<DataTemplate>
 					<TextBlock Text="{Binding Name}" />

--- a/UI/Windows/GameConfigWindow.axaml
+++ b/UI/Windows/GameConfigWindow.axaml
@@ -43,13 +43,13 @@
 			</TabItem>
 			<TabItem Header="{l:Translate tabDipSwitches}" IsVisible="{CompiledBinding DipSwitches.DipSwitches.Count}">
 				<ScrollViewer>
-					<ItemsControl Items="{CompiledBinding DipSwitches.DipSwitches}">
+					<ItemsControl ItemsSource="{CompiledBinding DipSwitches.DipSwitches}">
 						<ItemsControl.ItemTemplate>
 							<DataTemplate>
 								<Grid ColumnDefinitions="1*, 1*" RowDefinitions="Auto">
 									<TextBlock Text="{Binding Name}" />
 									<ComboBox
-										Items="{Binding Options}"
+										ItemsSource="{Binding Options}"
 										SelectedIndex="{Binding SelectedOption}"
 										Grid.Column="2"
 										HorizontalAlignment="Stretch"

--- a/UI/Windows/HdPackBuilderWindow.axaml
+++ b/UI/Windows/HdPackBuilderWindow.axaml
@@ -33,11 +33,11 @@
 			<c:OptionSection Grid.Row="1" Grid.ColumnSpan="2" Header="{l:Translate grpOptions}">
 				<Grid ColumnDefinitions="Auto,150,Auto" RowDefinitions="Auto,Auto">
 					<TextBlock VerticalAlignment="Center" Text="{l:Translate lblScale}" />
-					<ComboBox Grid.Column="1" HorizontalAlignment="Stretch" Items="{CompiledBinding Filters}" SelectedItem="{CompiledBinding SelectedFilter}" />
+					<ComboBox Grid.Column="1" HorizontalAlignment="Stretch" ItemsSource="{CompiledBinding Filters}" SelectedItem="{CompiledBinding SelectedFilter}" />
 					<Image Grid.Column="2" Stretch="None" Margin="5 0" Source="/Assets/Help.png" ToolTip.Tip="{l:Translate lblScaleHelp}" ToolTip.Placement="Right" ToolTip.ShowDelay="100" />
 
 					<TextBlock Grid.Row="1" VerticalAlignment="Center" Text="{l:Translate lblBankSize}" IsVisible="{CompiledBinding IsBankSizeVisible}" />
-					<ComboBox Grid.Column="1" Grid.Row="1" HorizontalAlignment="Stretch" Items="{CompiledBinding BankSizes}" SelectedItem="{CompiledBinding SelectedBankSize}" IsVisible="{CompiledBinding IsBankSizeVisible}" />
+					<ComboBox Grid.Column="1" Grid.Row="1" HorizontalAlignment="Stretch" ItemsSource="{CompiledBinding BankSizes}" SelectedItem="{CompiledBinding SelectedBankSize}" IsVisible="{CompiledBinding IsBankSizeVisible}" />
 					<Image Grid.Column="2" Grid.Row="1" Stretch="None" Margin="5 0" Source="/Assets/Help.png" ToolTip.Tip="{l:Translate lblBankSizeHelp}" ToolTip.Placement="Right" ToolTip.ShowDelay="100" IsVisible="{CompiledBinding IsBankSizeVisible}" />
 				</Grid>
 				<WrapPanel>

--- a/UI/Windows/HistoryViewerWindow.axaml
+++ b/UI/Windows/HistoryViewerWindow.axaml
@@ -22,8 +22,8 @@
 	
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
-			<MenuItem Header="{l:Translate mnuFile}" Items="{CompiledBinding FileMenuItems}" />
-			<MenuItem Header="{l:Translate mnuOptions}" Items="{CompiledBinding OptionsMenuItems}" />
+			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{CompiledBinding FileMenuItems}" />
+			<MenuItem Header="{l:Translate mnuOptions}" ItemsSource="{CompiledBinding OptionsMenuItems}" />
 		</c:MesenMenu>
 
 		<Border Name="ControlBar" BorderBrush="{StaticResource MesenGrayBorderColor}" BorderThickness="0 1 0 0" DockPanel.Dock="Bottom">

--- a/UI/Windows/HistoryViewerWindow.axaml.cs
+++ b/UI/Windows/HistoryViewerWindow.axaml.cs
@@ -105,7 +105,7 @@ namespace Mesen.Windows
 				return;
 			}
 
-			HistoryApi.HistoryViewerInitialize(PlatformImpl?.Handle.Handle ?? IntPtr.Zero, _renderer.Handle);
+			HistoryApi.HistoryViewerInitialize(TryGetPlatformHandle()?.Handle ?? IntPtr.Zero, _renderer.Handle);
 			_model.SetCoreOptions();
 			_model.Update();
 			_model.InitActions(this);

--- a/UI/Windows/MainWindow.axaml.cs
+++ b/UI/Windows/MainWindow.axaml.cs
@@ -95,7 +95,7 @@ namespace Mesen.Windows
 			_mainMenu = this.GetControl<MainMenuView>("MainMenu");
 			_mouseManager = new MouseManager(this, _renderer, _mainMenu);
 			ConfigManager.Config.MainWindow.LoadWindowSettings(this);
-
+			App.Clipboard = GetTopLevel(this)?.Clipboard;
 #if DEBUG
 			this.AttachDevTools();
 #endif
@@ -205,7 +205,7 @@ namespace Mesen.Windows
 				CommandLineHelper cmdLine = new CommandLineHelper(Program.CommandLineArgs, true);
 				_cmdLine = cmdLine;
 
-				EmuApi.InitializeEmu(ConfigManager.HomeFolder, PlatformImpl?.Handle.Handle ?? IntPtr.Zero, _renderer.Handle, cmdLine.NoAudio, cmdLine.NoVideo, cmdLine.NoInput);
+				EmuApi.InitializeEmu(ConfigManager.HomeFolder, TryGetPlatformHandle()?.Handle ?? IntPtr.Zero, _renderer.Handle, cmdLine.NoAudio, cmdLine.NoVideo, cmdLine.NoInput);
 
 				ConfigManager.Config.RemoveObsoleteConfig();
 				
@@ -490,7 +490,7 @@ namespace Mesen.Windows
 					WindowState = WindowState.FullScreen;
 
 					Task.Run(() => {
-						EmuApi.SetExclusiveFullscreenMode(true, PlatformImpl?.Handle.Handle ?? IntPtr.Zero);
+						EmuApi.SetExclusiveFullscreenMode(true, TryGetPlatformHandle()?.Handle ?? IntPtr.Zero);
 						_preventFullscreenToggle = false;
 					});
 				} else {

--- a/UI/Windows/SelectRomWindow.axaml
+++ b/UI/Windows/SelectRomWindow.axaml
@@ -32,7 +32,7 @@
 
 		<ListBox
 			Name="ListBox"
-			Items="{CompiledBinding FilteredEntries}"
+			ItemsSource="{CompiledBinding FilteredEntries}"
 			SelectedItem="{CompiledBinding SelectedEntry}"
 			DoubleTapped="OnDoubleTapped"
 			PointerReleased="OnPointerReleased"

--- a/makefile
+++ b/makefile
@@ -54,7 +54,9 @@ endif
 
 MESENFLAGS += -m64
 
-ifeq ($(DEBUG),)
+DEBUG ?= 0
+
+ifeq ($(DEBUG),0)
 	MESENFLAGS += -O3
 	ifneq ($(LTO),false)
 		MESENFLAGS += -flto -DHAVE_LTO
@@ -96,7 +98,15 @@ CXXFLAGS = -fPIC -Wall --std=c++17 $(MESENFLAGS) $(SDL2INC) -I $(realpath ./) -I
 CFLAGS = -fPIC -Wall $(MESENFLAGS)
 
 OBJFOLDER := obj.$(MESENPLATFORM)
+DEBUGFOLDER := bin/$(MESENPLATFORM)/Debug
 RELEASEFOLDER := bin/$(MESENPLATFORM)/Release
+ifeq ($(DEBUG), 0)
+    OUTFOLDER = $(RELEASEFOLDER)
+	BUILD_TYPE = Release
+else
+    OUTFOLDER = $(DEBUGFOLDER)
+	BUILD_TYPE = Debug
+endif
 
 PUBLISHFLAGS :=  -r $(MESENPLATFORM) --no-self-contained true -p:PublishSingleFile=true
 
@@ -140,12 +150,12 @@ endif
 all: ui
 
 ui: InteropDLL/$(OBJFOLDER)/$(SHAREDLIB)
-	mkdir -p $(RELEASEFOLDER)/Dependencies
-	rm -fr $(RELEASEFOLDER)/Dependencies/*
-	cp InteropDLL/$(OBJFOLDER)/$(SHAREDLIB) bin/$(MESENPLATFORM)/Release/$(SHAREDLIB)
+	mkdir -p $(OUTFOLDER)/Dependencies
+	rm -fr $(OUTFOLDER)/Dependencies/*
+	cp InteropDLL/$(OBJFOLDER)/$(SHAREDLIB) $(OUTFOLDER)/$(SHAREDLIB)
 	#Called twice because the first call copies native libraries to the bin folder which need to be included in Dependencies.zip
-	cd UI && dotnet publish -c Release -p:OptimizeUi="true" $(PUBLISHFLAGS)
-	cd UI && dotnet publish -c Release -p:OptimizeUi="true" $(PUBLISHFLAGS)
+	cd UI && dotnet publish -c $(BUILD_TYPE) -p:OptimizeUi="true" $(PUBLISHFLAGS)
+	cd UI && dotnet publish -c $(BUILD_TYPE) -p:OptimizeUi="true" $(PUBLISHFLAGS)
 
 core: InteropDLL/$(OBJFOLDER)/$(SHAREDLIB)
 
@@ -169,7 +179,7 @@ pgo:
 	./buildPGO.sh
 
 run:
-	./bin/$(MESENPLATFORM)/Release/$(MESENPLATFORM)/publish/Mesen
+	$(OUTFOLDER)/$(MESENPLATFORM)/publish/Mesen
 
 clean:
 	rm -r -f $(COREOBJ)


### PR DESCRIPTION
This change is blocked on AvaloniaEdit updating to the same preview version (shouldn't be much longer) https://github.com/AvaloniaUI/AvaloniaEdit/pull/332

The reason for updating is the native script window text area has a NullReferenceException which causes mesen to crash, and this change is fixed in preview7. 

The major changes are

* Global clipboard is removed for local view only clipboards. I resolved this by using the local clipboard where possible, and using a global clipboard when in a static context.
* Most Items properties seemingly became readonly, making binding not work on them. This changes to the ItemsSource property, but I'm not convinced this is correct, and I can't test as this change doesn't run right now with the AvaloniaEdit updates.
* https://github.com/SourMesen/Mesen2/compare/master...jroweboy:Mesen2:m2mac?expand=1#diff-af90f4d50048b1107627cb76867f01b1c739182d36073e7babcb9acc1220297aR18 -- This is OBVIOUSLY wrong, but i couldn't figure out how this ever worked... I plan to use a `#if` compiletime conditional to choose the proper library name, but i'm still left wondering how this seemingly runs right now without it.
* PlatformHandle is removed, but there is a TryGetPlatformHandle which does the same thing
* https://github.com/SourMesen/Mesen2/compare/master...jroweboy:Mesen2:m2mac?expand=1#diff-cc7e3150f07152b0e4d0f55499c2fca81387e464391f25750d9647437d09c274R5 -- This should allow the solution to be built directly from mac. I'm not sure if its intentional that you disallow building the solution directly from an IDE on non-windows...
* FontManager.Current.DefaultFontFamilyName -> FontManager.Current.DefaultFontFamily