### PR TITLE
Add AppImage build to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,21 +79,30 @@ jobs:
         run: |
           sudo apt-get update -qy
           sudo apt-get install -qy libsdl2-dev # The compilers are already installed on GitHub's runners.
-
+      
+      - name: Install PupNet Deploy
+        run: dotnet tool install -g KuiperZone.PupNet
+        
       - name: Execute unit tests
         run: dotnet test --nologo
 
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.
-      - name: Build Mesen
+      - name: Build Mesen (Standalone executeable)
         run: |
           make -j$(nproc) -O ${{ matrix.use_gcc }} LTO=true STATICLINK=true SYSTEM_LIBEVDEV=false
-
-      - name: Upload Mesen
+      - name: Upload Mesen (Standalone executeable)
         uses: actions/upload-artifact@v3
         with:
           name: Mesen (Linux - ${{ matrix.os }} - ${{ matrix.compiler }})
           path: bin/linux-x64/Release/linux-x64/publish/Mesen
+      - name: Build Mesen (AppImage)
+        run: pupnet --runtime linux-x64 --kind appimage
+      - name: Upload Mesen (AppImage)
+        uses: actions/upload-artifact@v3
+        with:
+          name: Mesen (Linux x64 - AppImage)
+          # TO-ADD: path
 
   macos:
     strategy:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The latest release is available from the [releases](https://github.com/SourMesen
 
 Latest development builds:  
 [Windows](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%29.zip)  
-[Linux](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-20.04%20-%20clang%29.zip)  
+[Linux](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-20.04%20-%20clang%29.zip), AppImage (TO-DO)  
 
 **macOS**: Dev builds aren't available for ARM Macs. It's recommended to build it yourself by running `make`. The macOS build is still **experimental** and a number of issues/bugs/limitations remain, but it seems to be usable for the most part.
 
@@ -21,7 +21,8 @@ Latest development builds:
 To run Mesen, the following prerequisites must be installed:  
 
 **Windows**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)  
-**Linux**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0), SDL2  
+**Linux**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0), SDL2
+	- When using an AppImage build, these prerequisites would not be necessary to be installed on the Linux machine.
 **macOS**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0), SDL2  
 
 ## Compiling

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ To run Mesen, the following prerequisites must be installed:
 
 **Windows**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)  
 **Linux**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0), SDL2
-	- When using an AppImage build, these prerequisites would not be necessary to be installed on the Linux machine.
+	
+ - When using an AppImage build, these prerequisites would not be necessary to be installed on the Linux machine.
+
 **macOS**: [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0), SDL2  
 
 ## Compiling


### PR DESCRIPTION
To be able to run Mesen on systems that can not install .NET's runtime on Linux because of an immutable root file system ([Fedora Silverblue](https://fedoraproject.org/silverblue/), Steam Deck's [SteamOS 3](https://partner.steamgames.com/doc/steamdeck/faq#6) etc.), I have been trying to figure out how to adjust the current CI/CD pipeline to build AppImages.

[AppImages](https://appimage.org/) are similar to Windows' `.exe` executable files, only with dependencies built-in so that any Linux system should in theory run the application regardless which dependencies are installed through their own package manager.

For .NET applications, [Pupnet Deploy](https://github.com/kuiperzone/PupNet-Deploy) seemed like an easy and fitting tool for this task. It's a dotnet tool that helps with packaging applications into AppImages, but also into other formats ([Flatpak, another packaging solution used nowadays](https://flatpak.org/), Debian packages, RPM packages and at last InnoSetup executables for Windows operating systems).

To publish Mesen into AppImage form, the following files should be present:

- A `pupnet.conf` configuration file present with some metadata (app name and ID, version, description, license etc.). -- Easily generated by running `pupnet [name] --new conf` in the project root directory.
- A `.desktop` desktop file, which will be automatically filled in based on `pupnet.conf`'s data values while leaving room for manual overrides. -- Easily generated by running `pupnet [name] --new desktop` in the project root directory.
- (Optional) A `.metainfo.xml` file for metadata used by 
software centers to display information about Mesen. -- Easily generated by running `pupnet [name] --new meta` in the root project directory.
- Icon files specified.

I have tried to use the dotnet tool to package Mesen into an AppImage locally on WSL2 using the template HelloWorld versions of the required files, but I seem to get stuck at an error stating it is missing some file [(Log is available as an attachment.)](https://github.com/SourMesen/Mesen2/files/11895852/mesen2_pupnet_log.txt).

Edit: Even after building Mesen standalone which would resolve the `MesenCore.so` error - the build still fails. Even when adjusting the publisher arguments to match that of Mesen - `dotnet publsh` fails to build at the moment when doing it through `pupnet`. Standalone builds work fine.

I figured opening this draft Pull Request in the hope either someone else could ring in to help realising this, or myself managing to package it and then reproduce it through GitHub Actions.