### PR TITLE
WlaDxImporter: Ignore fileId with a mapping of 0

### DIFF
--- a/UI/Debugger/Integration/WlaDxImporter.cs
+++ b/UI/Debugger/Integration/WlaDxImporter.cs
@@ -210,6 +210,12 @@ public class WlaDxImporter : ISymbolProvider
 							int fileId = Int32.Parse(m.Groups[field_idx].Value, System.Globalization.NumberStyles.HexNumber);
 							int lineNumber = Int32.Parse(m.Groups[line_idx].Value, System.Globalization.NumberStyles.HexNumber);
 
+							if(fileId == 0) {
+								// WLA-DX can generate invalid file mappings if a file is optimized away. Ignore these mappings.
+								errorCount++;
+								continue;
+							}
+
 							if(lineNumber <= 1) {
 								//Ignore line number 0 and 1, seems like bad data?
 								errorCount++;


### PR DESCRIPTION
WLA-DX can generate files with null line mappings. This will happen if your source file does not have any labels directly but does .include other files with labels.

`games/sprites.i`
```
.section "Sprites" bank 3 slot "ROM"
.include "resources/sprites/plane/plane.i"
.ends
```

The generated symbols
```
[source files v2]
0001:0001 3a35f56a game\main.asm 
...

[addr-to-line mapping v2]
...
00018002 03:0002 8002 0001:0000:000018f1
00018005 03:0005 8005 0001:0000:00000000
000198f8 03:18f8 98f8 0001:0000:000018f4
000198f9 03:18f9 98f9 0001:0000:00000001
000198fb 03:18fb 98fb 0001:0000:00000000
```

The specific error here is the `addr-to-line` mapping. It is requesting source file 0, which does not exist. This cause the debugger to error:
![image](https://github.com/SourMesen/Mesen2/assets/45720/99190df9-0e9c-45e9-9472-f28f566b6c59)

The better fix would be to have `WLA-DX` fix their mapping generation, but we can handle the error pretty simply in the absence of that.