### PR TITLE
Tile editor: fix crash under i3 window manager

### DIFF
--- a/UI/Debugger/ViewModels/TileEditorViewModel.cs
+++ b/UI/Debugger/ViewModels/TileEditorViewModel.cs
@@ -263,7 +263,10 @@ public class TileEditorViewModel : DisposableViewModel
 	private void SetPixelColor(PixelPoint position, int color)
 	{
 		TilePixelPositionInfo pos = GetPositionInfo(position);
-		DebugApi.SetTilePixel(_tileAddresses[pos.Column + pos.Row * _columnCount], _tileFormat, pos.TileX, pos.TileY, color);
+		int tileIndex = pos.Column + pos.Row * _columnCount;
+		if (tileIndex < _tileAddresses.Count) {
+			DebugApi.SetTilePixel(_tileAddresses[tileIndex], _tileFormat, pos.TileX, pos.TileY, color);
+		}
 	}
 
 	public void UpdatePixel(PixelPoint position, bool clearPixel)


### PR DESCRIPTION
To reproduce the crash:

1. Run Mesen on Linux under the [i3 window manager](https://i3wm.org).
2. Open a tile in the tile editor.
3. Click and hold while the cursor is within the tile, then drag the cursor outside of the tile and release the mouse button.
4. Mesen crashes with an uncaught `IndexOutOfRangeException`.

I'm not sure exactly what the root cause is, but I'm guessing i3 is reporting bounds in some way that doesn't quite agree with what Avalonia expects. (That's not uncommon with GUI apps in a tiling window manager.) This seems like a simple fix: just check whether the position is actually within the tile before modifying the tile.

Let me know if you have any questions!