### PR TITLE
UI: Respect data storage location setting

### DIFF
--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -81,6 +81,11 @@ namespace Mesen
 				Program.CommandLineArgs = (string[])args.Clone();
 				BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, ShutdownMode.OnMainWindowClose);
 				EmuApi.Release();
+
+				//Cleanup portable installation
+				if(ConfigManager.HomeFolder == ConfigManager.DefaultPortableFolder && Directory.Exists(ConfigManager.DefaultDocumentsFolder)) {
+					Directory.Delete(ConfigManager.DefaultDocumentsFolder, true);
+				}
 			}
 
 			return 0;


### PR DESCRIPTION
# Issue

On the initial configuration wizard when the following is set:

![image](https://github.com/SourMesen/Mesen2/assets/81951119/68f0169b-7989-4538-9085-3e2c5d5caeaa)

The program will create duplicated files in the user profile regardless:

![image](https://github.com/SourMesen/Mesen2/assets/81951119/a8b3bfdb-d84e-4c58-8dbd-9c8afe43246c)

# Fix

Remove redundant calls of `ExtractNativeDependencies()` and let the following method call it:

https://github.com/SourMesen/Mesen2/blob/c0e7d9faac6e3a7ceb49ca6c102d38b15dbc8307/UI/Config/ConfigManager.cs#L46

N.B. An empty directory "Mesen2" will still be created in the user profile. I can add that folder not being created with the above setting if this is a wanted change.
