### PR TITLE
NES: Fixed mapper 80 SRAM/WRAM recognition

### DIFF
--- a/Core/NES/Mappers/Taito/TaitoX1005.h
+++ b/Core/NES/Mappers/Taito/TaitoX1005.h
@@ -24,6 +24,11 @@ protected:
 	uint32_t GetSaveRamSize() override { return 0x100; }
 	uint32_t GetSaveRamPageSize() override { return 0x100; }
 
+	// FIXME: SRAM/WRAM size is actually 128 bytes, and mirrored once on $7F00-$7FFF.
+	// reference: https://www.nesdev.org/wiki/INES_Mapper_080
+	bool ForceSaveRamSize() override { return HasBattery(); }
+	bool ForceWorkRamSize() override { return !HasBattery(); }
+
 	void InitMapper() override
 	{
 		_ramPermission = 0;


### PR DESCRIPTION
This fixes issues in "Mirai Shinwa Jarvas (J)".

## Problem

"Mirai Shinwa Jarvas (J)" uses mapper 80, and it has a battery-backed Save RAM (128 bytes).
But, Mesen2 (commit 6ed7e45bd4dea40b63de47db961ca95d583dcf87) doesn't recognize the Save RAM.

To reproduce the issue:

* Open the "Mirai Shinwa Jarvas (J)" (headerless SHA-1 hash: 60814331ae3bf1cff00d96aa41ff8bcc94d3c574).
* Press Start on the title screen.
* Press Select to open the menu.
* Select the menu entry "おわる", and press A.
* The game is softlocked because the Save RAM doesn't exist.

![MiraiShinwaJarvas-save](https://github.com/SourMesen/Mesen2/assets/21364118/b31baf23-e6b5-40cb-86bc-dd3dab94b9a2)

## Solution

I overrided `ForceSaveRamSize()` and `ForceWorkRamSize()` in `TaitoX1005` to recognize the SRAM/WRAM.

I considered modifying the game database, but it seems that I can only specify SRAM/WRAM sizes in kilobyte units.

Note: this is not a perfect emulation. According to [NesDev Wiki](https://www.nesdev.org/wiki/INES_Mapper_080), the mapper 80 has only 128 bytes SRAM/WRAM, and it is mirrored once on `$7F00-$7FFF`. But it was difficult for me to implement this behavior correctly.
