### PR TITLE
Audio rebalancing to more closely approximate the original Famicom HV…

### DIFF
--- a/Core/NES/NesSoundMixer.cpp
+++ b/Core/NES/NesSoundMixer.cpp
@@ -177,7 +177,7 @@ double NesSoundMixer::GetChannelOutput(AudioChannel channel, bool forRightChanne
 int16_t NesSoundMixer::GetOutputVolume(bool forRightChannel)
 {
 	double squareOutput = GetChannelOutput(AudioChannel::Square1, forRightChannel) + GetChannelOutput(AudioChannel::Square2, forRightChannel);
-	double tndOutput = GetChannelOutput(AudioChannel::DMC, forRightChannel) + 2.7516713261 * GetChannelOutput(AudioChannel::Triangle, forRightChannel) + 1.8493587125 * GetChannelOutput(AudioChannel::Noise, forRightChannel);
+	double tndOutput = 1.0966713261 * GetChannelOutput(AudioChannel::DMC, forRightChannel) + 2.7516713261 * GetChannelOutput(AudioChannel::Triangle, forRightChannel) + 1.8493587125 * GetChannelOutput(AudioChannel::Noise, forRightChannel);
 
 	uint16_t squareVolume = (uint16_t)((95.88*5000.0) / (8128.0 / squareOutput + 100.0));
 	uint16_t tndVolume = (uint16_t)((159.79*5000.0) / (22638.0 / tndOutput + 100.0));
@@ -187,7 +187,7 @@ int16_t NesSoundMixer::GetOutputVolume(bool forRightChannel)
 		GetChannelOutput(AudioChannel::MMC5, forRightChannel) * 43 +
 		GetChannelOutput(AudioChannel::Namco163, forRightChannel) * 20 +
 		GetChannelOutput(AudioChannel::Sunsoft5B, forRightChannel) * 15 +
-		GetChannelOutput(AudioChannel::VRC6, forRightChannel) * 75 +
+		GetChannelOutput(AudioChannel::VRC6, forRightChannel) * 48 +
 		GetChannelOutput(AudioChannel::VRC7, forRightChannel));
 }
 void NesSoundMixer::AddDelta(AudioChannel channel, uint32_t time, int16_t delta)


### PR DESCRIPTION
…C-001 model.

This is thanks to @riggles1 from https://github.com/libretro/Mesen/pull/44

Reviewed the audio mixing in comparison with real hardware audio capture (HVC-001), Mesen currently sounds more similar to the HVC-101, better known as the AV Famicom. Meaning that the VRC6 volume is greatly overpowering the other channels (many times harmonies or additional background melody being inaudible) as well as a very weak DMC Sample channel making the drums hardly present. Both of these volume levels were tweaked in this pull request. Soundtracks like Akumajou Densetsu were composed with the original model 001 mixing in mind.

I adjusted the mixing to arrive at the following results showcased in this video. With the changes (first) and what the Mesen core currently sounds like (second). https://www.youtube.com/watch?v=gxgKe__TCgo The VRC6 sawtooth bass used to be so loud that it was also popping a bit.

Real hardware capture examples can be heard in the RetroRGB article regarding this: https://www.retrorgb.com/av-famicom-hvc-101-audio-balance-restoration-mod.html

This doesn't impact other games negatively, it especially helps music that utilizes a lot of drum or bass samples, techniques heavily used by developers at Konami and Sunsoft for example.