### PR TITLE
NES: Fix Studybox nametable mirroring

### DIFF
--- a/Core/NES/Loaders/StudyBoxLoader.cpp
+++ b/Core/NES/Loaders/StudyBoxLoader.cpp
@@ -128,7 +128,7 @@ void StudyBoxLoader::LoadRom(RomData& romData, vector<uint8_t>& romFile, string 
 
 	romData.Info.Format = RomFormat::StudyBox;
 	romData.Info.MapperID = MapperFactory::StudyBoxMapperID;
-	romData.Info.Mirroring = MirroringType::Vertical;
+	romData.Info.Mirroring = MirroringType::FourScreens;
 	romData.Info.System = GameSystem::Famicom;
 
 	romData.StudyBox.FileName = filepath;

--- a/Core/NES/Mappers/StudyBox.h
+++ b/Core/NES/Mappers/StudyBox.h
@@ -75,8 +75,6 @@ protected:
 		SetCpuMemoryMapping(0x4000, 0x4FFF, 8, PrgMemoryType::WorkRam);
 		RemoveCpuMemoryMapping(0x4000, 0x43FF);
 
-		SetMirroringType(MirroringType::FourScreens);
-
 		_emu->GetSoundMixer()->RegisterAudioProvider(this);
 	}
 


### PR DESCRIPTION
The Studybox has four-screen mirroring, but Mesen2 is currently doing vertical mirroring instead (while _saying_ that it does four screens).

While `StudyBox::InitMapper` tries to force the mirroring to four-screen (which is why the UI _says_ it has that), that is run _after_ `BaseMapper::Initialize` (which allocates memory for 2 nametables based on the ROM info) - and the `SetMirroringType` call does not allocate more memory, it just ignores the higher nametable indexes.

This PR makes the Studybox ROM loader set four-screen mirroring instead of vertical, which makes `Initialize` allocate enough nametables, and removes the now-extraneous `SetMirroringType` call from the mapper.

Unfortunately I have not been able to test this code (beyond building it), since I don't have a Studybox ROM and tape right now (I looked into it after I saw a streamer encounter the problem, a tape had worse graphics than on hardware, and the tilemap viewer showed what was happening), but I believe it should work.

If not, I think an alternate fix would be to override `GetNametableCount` in the `StudyBox` mapper to return 4, which should also make `Initialize` allocate enough nametables, independently of the ROM info - but I haven't tried that.