### PR TITLE
Enable and link macOS builds in the README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
       # forcing colours makes the log a little nicer to read.
       - name: Build Mesen
         run: |
-          make -j$(nproc)
+          make -j$(sysctl -n hw.logicalcpu)
 
       - name: Sign binary
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         compiler: [clang]
-        os: [macos-11, macos-12]
+        os: [macos-11, macos-12, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Mesen is a multi-system emulator (NES, SNES, Game Boy, PC Engine, Master System/
 Latest development builds:  
 
 * [Windows](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%29.zip)  
+* [macOS - Intel](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-12%29%20.zip)  
+* [macOS - Apple Silicon](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-14%29%20.zip)  
 * [Linux](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-20.04%20-%20clang%29.zip)  
 * [Linux - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)
 
-**macOS**: Builds aren't available for ARM Macs, see [COMPILING.md](COMPILING.md) to build it yourself. The macOS build still has a number of limitations (e.g no gamepad support).
+**macOS**: The macOS build still has a number of limitations (e.g no gamepad support).
 
 **SteamOS**: Running Mesen through the Steam Deck's _Game Mode_ is possible with some caveats regarding rendering the UI.
  	<details>


### PR DESCRIPTION
macOS M1 build runners are now available using the `macos-14` tag, so this PR adds that build runner and links them in the README. I don't really mind if you don't want them in the readme yet, but i think they are plenty stable in my experience.