### PR TITLE
Tile viewer

### DIFF
--- a/UI/Debugger/Utilities/ContextMenuAction.cs
+++ b/UI/Debugger/Utilities/ContextMenuAction.cs
@@ -835,6 +835,12 @@ namespace Mesen.Debugger.Utilities
 		
 		[IconFile("HdPack")]
 		CopyToHdPackFormat,
+		
+		[IconFile("CheatCode")]
+		CopyTileMemory,
+
+		[IconFile("Paste")]
+		PasteTileMemory,
 
 		[IconFile("Find")]
 		CheatDatabase,

--- a/UI/Debugger/Utilities/MemCopyHelper.cs
+++ b/UI/Debugger/Utilities/MemCopyHelper.cs
@@ -38,9 +38,9 @@ namespace Mesen.Debugger.Utilities
 				case MemoryType.NesChrRom:
 				case MemoryType.NesChrRam:
 					for(int i = 0; i < len; i++) {
-            if (sb.Length > 0) {
-              sb.Append(" ");
-            }
+						if(sb.Length > 0) {
+							sb.Append(" ");
+						}
 						sb.Append(DebugApi.GetMemoryValue(tileAddr.Type, (uint)(tileAddr.Address + i)).ToString("X2"));
 					}
 					break;

--- a/UI/Debugger/Utilities/MemCopyHelper.cs
+++ b/UI/Debugger/Utilities/MemCopyHelper.cs
@@ -1,0 +1,82 @@
+using Avalonia;
+using Mesen.Interop;
+using Mesen.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Tmds.DBus;
+
+namespace Mesen.Debugger.Utilities
+{
+	public static class MemCopyHelper
+	{
+		public static bool IsActionAllowed(MemoryType type)
+		{
+			return type switch {
+				MemoryType.NesPpuMemory => true,
+				MemoryType.NesChrRam => true,
+				MemoryType.NesChrRom => true,
+				MemoryType.NesPrgRom => true,
+				_ => false,
+			};
+		}
+
+		public static string ToString(AddressInfo tileAddr, int len)
+		{
+			StringBuilder sb = new StringBuilder();
+
+			if(tileAddr.Type == MemoryType.NesPpuMemory) {
+				tileAddr = DebugApi.GetAbsoluteAddress(tileAddr);
+			}
+
+			switch(tileAddr.Type) {
+				case MemoryType.NesPrgRom:
+				case MemoryType.NesChrRom:
+				case MemoryType.NesChrRam:
+					for(int i = 0; i < len; i++) {
+            if (sb.Length > 0) {
+              sb.Append(" ");
+            }
+						sb.Append(DebugApi.GetMemoryValue(tileAddr.Type, (uint)(tileAddr.Address + i)).ToString("X2"));
+					}
+					break;
+
+				default:
+					return "";
+			}
+
+			return sb.ToString();
+		}
+
+		public static void CopyTileMem(int address, MemoryType memoryType)
+		{
+			AddressInfo addr = new AddressInfo() { Address = address, Type = memoryType };
+			string tileMem = MemCopyHelper.ToString(addr, 16);
+
+			if(tileMem.Length > 0) {
+				ApplicationHelper.GetMainWindow()?.Clipboard?.SetTextAsync(tileMem);
+			}
+		}
+
+		public static void PasteTileMem(int address, MemoryType memoryType)
+		{
+			var clipboard = ApplicationHelper.GetMainWindow()?.Clipboard;
+			if(clipboard != null) {
+				string? text = Task.Run(() => clipboard?.GetTextAsync()).GetAwaiter().GetResult();
+				if(text != null) {
+					text = text.Replace("\n", "").Replace("\r", "").Replace(" ", "");
+					if(Regex.IsMatch(text, "^[A-F0-9]{32}$", RegexOptions.IgnoreCase)) {
+						byte[] pastedData = HexUtilities.HexToArray(text);
+						for(int i = 0; i < 16; i++) {
+							DebugApi.SetMemoryValue(memoryType, (uint)(address + i), (byte)pastedData[i]);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/UI/Debugger/ViewModels/TileViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TileViewerViewModel.cs
@@ -197,6 +197,28 @@ namespace Mesen.Debugger.ViewModels
 							HdPackCopyHelper.CopyToHdPackFormat(address, Config.Source, RawPalette, SelectedPalette, false);
 						}
 					}
+				},
+				new ContextMenuAction() {
+					ActionType = ActionType.CopyTileMemory,
+					IsVisible = () => CpuType == CpuType.Nes,
+					IsEnabled = () => GetSelectedTileAddress() >= 0,
+					OnClick = () => {
+						int address = GetSelectedTileAddress();
+						if(address >= 0) {
+							MemCopyHelper.CopyTileMem(address, Config.Source);
+						}
+					}
+				},
+				new ContextMenuAction() {
+					ActionType = ActionType.PasteTileMemory,
+					IsVisible = () => CpuType == CpuType.Nes,
+					IsEnabled = () => GetSelectedTileAddress() >= 0,
+					OnClick = () => {
+						int address = GetSelectedTileAddress();
+						if(address >= 0) {
+							MemCopyHelper.PasteTileMem(address, Config.Source);
+						}
+					}
 				}
 			});
 

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -3296,6 +3296,8 @@ E
 			<Value ID="ResetAccessCounters">Reset access stats</Value>
 
 			<Value ID="CopyToHdPackFormat">Copy tile (HD pack format)</Value>
+			<Value ID="CopyTileMemory">Copy tile (memory)</Value>
+			<Value ID="PasteTileMemory">Paste tile (memory)</Value>
 			<Value ID="CheatDatabase">Cheat database</Value>
 			<Value ID="ToggleBilinearInterpolation">Use bilinear interpolation</Value>
 


### PR DESCRIPTION
@SourMesen 

This change allows the user to copy and paste individual tiles in Tile Viewer. It works with the underlying memory rather than pixels. A typical use case would be to copy edits from CHR-RAM back into PRG-ROM. Previously I was doing this manually using multiple instances of Memory Viewer with a combination of search and copy/paste. It was a headache and error prone. This is also useful for creating new tiles that are based on existing ones.