### PR TITLE
Debugger: Tile Viewer - Add navigate by tile button to Address row

### DIFF
--- a/UI/Debugger/Controls/HexInput.axaml
+++ b/UI/Debugger/Controls/HexInput.axaml
@@ -7,7 +7,7 @@
 	xmlns:c="using:Mesen.Controls"
 	xmlns:u="using:Mesen.Utilities"
 	mc:Ignorable="d"
-	MinWidth="120"
+	MinWidth="140"
 	x:Name="root"
 	HorizontalAlignment="Stretch"
 	x:Class="Mesen.Debugger.Controls.HexInput"
@@ -16,11 +16,14 @@
 		<StreamGeometry x:Key="FirstButton">M7,0 L2,5 7,10 M0,0 L0,10</StreamGeometry>
 		<StreamGeometry x:Key="LargeButton">M0,0 L5,5 0,10 M7,0 L7,10</StreamGeometry>
 
-		<StreamGeometry x:Key="PrevLargeButton">M7,0 L3,5 7,10 M3,0 L0,5 3,10</StreamGeometry>
-		<StreamGeometry x:Key="NextLargeButton">M0,0 L4,5 0,10 M4,0 L7,5 4,10</StreamGeometry>
+		<StreamGeometry x:Key="PrevLargeButton">M7,0 L3,4 7,8 M3,0 L-1,4 3,8</StreamGeometry>
+		<StreamGeometry x:Key="NextLargeButton">M-1,0 L3,4 -1,8 M3,0 L7,4 3,8</StreamGeometry>
 
-		<StreamGeometry x:Key="PrevSmallButton">M5,0 L0,5 5,10</StreamGeometry>
-		<StreamGeometry x:Key="NextSmallButton">M0,0 L5,5 0,10</StreamGeometry>
+		<StreamGeometry x:Key="PrevMediumButton">M2,0 L-2,4 2,8</StreamGeometry>
+		<StreamGeometry x:Key="NextMediumButton">M0,0 L4,4 0,8</StreamGeometry>
+
+		<StreamGeometry x:Key="PrevSmallButton">M0,1 H6</StreamGeometry>
+		<StreamGeometry x:Key="NextSmallButton">M0,3 H6 M3,0 V6</StreamGeometry>
 	</UserControl.Resources>
 
 	<UserControl.Styles>
@@ -30,10 +33,11 @@
 			<Setter Property="Padding" Value="4 0" />
 			<Setter Property="MinHeight" Value="21" />
 			<Setter Property="VerticalContentAlignment" Value="Center"/>
+			<Setter Property="HorizontalContentAlignment" Value="Center"/>
 		</Style>
 		<Style Selector="Path">
 			<Setter Property="Stroke" Value="{DynamicResource ButtonForeground}"/>
-			<Setter Property="StrokeThickness" Value="2"/>
+			<Setter Property="StrokeThickness" Value="0.75"/>
 		</Style>
 		<Style Selector="RepeatButton:disabled Path">
 			<Setter Property="Stroke" Value="{DynamicResource ButtonForegroundDisabled}"/>
@@ -44,11 +48,17 @@
 		<RepeatButton Command="{Binding DecrementLarge}" DockPanel.Dock="Left" ToolTip.Tip="Previous page">
 			<Path Data="{StaticResource PrevLargeButton}" />
 		</RepeatButton>
+		<RepeatButton Command="{Binding DecrementMedium}" DockPanel.Dock="Left" ToolTip.Tip="Previous tile" Margin="-1 0 0 0">
+			<Path Data="{StaticResource PrevMediumButton}"/>
+		</RepeatButton>
 		<RepeatButton Command="{Binding DecrementSmall}" DockPanel.Dock="Left" ToolTip.Tip="Previous byte" Margin="-1 0 0 0">
 			<Path Data="{StaticResource PrevSmallButton}"/>
 		</RepeatButton>
 		<RepeatButton Command="{Binding IncrementLarge}"  DockPanel.Dock="Right" ToolTip.Tip="Next page">
 			<Path Data="{StaticResource NextLargeButton}" />
+		</RepeatButton>
+		<RepeatButton Command="{Binding IncrementMedium}"  DockPanel.Dock="Right" ToolTip.Tip="Next tile" Margin="0 0 -1 0">
+			<Path Data="{StaticResource NextMediumButton}" />
 		</RepeatButton>
 		<RepeatButton Command="{Binding IncrementSmall}" DockPanel.Dock="Right" ToolTip.Tip="Next byte" Margin="0 0 -1 0">
 			<Path Data="{StaticResource NextSmallButton}" />

--- a/UI/Debugger/Controls/HexInput.axaml.cs
+++ b/UI/Debugger/Controls/HexInput.axaml.cs
@@ -13,6 +13,7 @@ namespace Mesen.Debugger.Controls
 		public static readonly StyledProperty<int?> MaximumProperty = AvaloniaProperty.Register<HexInput, int?>(nameof(Maximum));
 		public static readonly StyledProperty<int?> MinimumProperty = AvaloniaProperty.Register<HexInput, int?>(nameof(Minimum));
 		public static readonly StyledProperty<int> SmallIncrementProperty = AvaloniaProperty.Register<HexInput, int>(nameof(SmallIncrement));
+		public static readonly StyledProperty<int> MediumIncrementProperty = AvaloniaProperty.Register<HexInput, int>(nameof(MediumIncrement));
 		public static readonly StyledProperty<int> LargeIncrementProperty = AvaloniaProperty.Register<HexInput, int>(nameof(LargeIncrement));
 
 		public int Value
@@ -37,6 +38,12 @@ namespace Mesen.Debugger.Controls
 		{
 			get { return GetValue(SmallIncrementProperty); }
 			set { SetValue(SmallIncrementProperty, value); }
+		}
+
+		public int MediumIncrement
+		{
+			get { return GetValue(MediumIncrementProperty); }
+			set { SetValue(MediumIncrementProperty, value); }
 		}
 
 		public int LargeIncrement
@@ -70,6 +77,11 @@ namespace Mesen.Debugger.Controls
 			SetValue(LargeIncrement);
 		}
 
+		private void OnNextMediumClick(object sender, RoutedEventArgs e)
+		{
+			SetValue(MediumIncrement);
+		}
+
 		private void OnNextSmallClick(object sender, RoutedEventArgs e)
 		{
 			SetValue(SmallIncrement);
@@ -97,6 +109,17 @@ namespace Mesen.Debugger.Controls
 			return Value > 0;
 		}
 
+		public void DecrementMedium(object parameter)
+		{
+			SetValue(-MediumIncrement);
+		}
+
+		[DependsOn(nameof(Value))]
+		public bool CanDecrementMedium(object parameter)
+		{
+			return Value >= MediumIncrement;
+		}
+
 		public void IncrementLarge(object parameter)
 		{
 			SetValue(LargeIncrement);
@@ -108,6 +131,19 @@ namespace Mesen.Debugger.Controls
 		public bool CanIncrementLarge(object parameter)
 		{
 			return Value < Maximum && Value < Maximum - LargeIncrement + 1;
+		}
+
+		public void IncrementMedium(object parameter)
+		{
+			SetValue(MediumIncrement);
+		}
+
+		[DependsOn(nameof(Value))]
+		[DependsOn(nameof(Maximum))]
+		[DependsOn(nameof(MediumIncrement))]
+		public bool CanIncrementMedium(object parameter)
+		{
+			return Value < Maximum && Value < Maximum - MediumIncrement + 1;
 		}
 
 		public void IncrementSmall(object parameter)

--- a/UI/Debugger/ViewModels/TileViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TileViewerViewModel.cs
@@ -44,6 +44,7 @@ namespace Mesen.Debugger.ViewModels
 		[Reactive] public int SelectedPalette { get; set; } = 0;
 
 		[Reactive] public int AddressIncrement { get; private set; }
+		[Reactive] public int TileIncrement { get; private set; }
 		[Reactive] public int MaximumAddress { get; private set; } = int.MaxValue;
 
 		[Reactive] public int GridSizeX { get; set; } = 8;
@@ -235,12 +236,20 @@ namespace Mesen.Debugger.ViewModels
 			}));
 
 			AddDisposable(this.WhenAnyValue(x => x.Config.ColumnCount, x => x.Config.RowCount, x => x.Config.Format).Subscribe(x => {
+
+				PixelSize tileSize = Config.Format.GetTileSize();
+
+				int bitsPerPixel = Config.Format.GetBitsPerPixel();
+				int bytesPerTile = tileSize.Width * tileSize.Height * bitsPerPixel / 8;
+
 				//Enforce min/max values for column/row counts
 				Config.ColumnCount = ColumnCount;
 				Config.RowCount = RowCount;
 
 				ApplyColumnRowCountRestrictions();
-				AddressIncrement = ColumnCount * RowCount * 8 * 8 * Config.Format.GetBitsPerPixel() / 8;
+
+				TileIncrement = bytesPerTile;
+				AddressIncrement = ColumnCount * RowCount * bytesPerTile;
 			}));
 
 			AddDisposable(this.WhenAnyValue(x => x.Config.Source).Subscribe(memType => {

--- a/UI/Debugger/Windows/TileViewerWindow.axaml
+++ b/UI/Debugger/Windows/TileViewerWindow.axaml
@@ -98,6 +98,7 @@
 						Grid.Column="1" Grid.Row="3"
 						Value="{CompiledBinding Config.StartAddress}"
 						LargeIncrement="{CompiledBinding AddressIncrement}"
+						MediumIncrement="{CompiledBinding TileIncrement}"
 						SmallIncrement="1"
 						Minimum="0"
 						Maximum="{CompiledBinding MaximumAddress}"


### PR DESCRIPTION
Adds an additional button to navigate the tile viewer by one tile at a time. I also cleaned up the buttons a bit and made them match the rest of the panel better. Ends up looking like this:

![Screenshot 2024-04-03 183827](https://github.com/SourMesen/Mesen2/assets/104513/7032da80-08d8-4460-885d-c7e91c0c9fdd)
