### PR TITLE
Fix MMC5 sprite display when using 8x16 mode with 8kb window and reduce sprite flicker enabled

### DIFF
--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -913,13 +913,18 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 				//copy vertical scrolling value from t
 				_videoRamAddr = (_videoRamAddr & ~0x7BE0) | (_tmpVideoRamAddr & 0x7BE0);
 			}
+			// Load the extra sprites before tile loading starts (which matters for MMC5)
+			// The CHR banks are switched back to the bg tileset in LoadTileInfo on cycle 321
+			// and the extra sprites will potentially read from the wrong banks
+			if(_cycle == 320) {
+				LoadExtraSprites();
+			}
 		}
 	} else if(_cycle >= 321 && _cycle <= 336) {
 		LoadTileInfo();
 
 		if(_cycle == 321) {
 			if(IsRenderingEnabled()) {
-				LoadExtraSprites();
 				_oamCopybuffer = _secondarySpriteRam[0];
 			}
 		} else if(_prevRenderingEnabled && (_cycle == 328 || _cycle == 336)) {


### PR DESCRIPTION
If all of those options are on, the extra sprites will be pulled from the bg tile banks instead of the sprite banks.