### PR TITLE
MacOS: Fix cursor oddness

### DIFF
--- a/UI/Utilities/MouseManager.cs
+++ b/UI/Utilities/MouseManager.cs
@@ -139,7 +139,8 @@ namespace Mesen.Utilities
 		private void SetMouseCursor(CursorImage icon)
 		{
 			InputApi.SetCursorImage(icon);
-			if(_usesSoftwareRenderer) {
+			if(_usesSoftwareRenderer && !OperatingSystem.IsMacOS()) {
+				//On MacOS, also setting the cursor on the renderer causes the cursor visibility to act oddly
 				_renderer.Cursor = new Cursor(icon.ToStandardCursorType());
 			}
 		}


### PR DESCRIPTION
It looks like setting both the cursor on the software renderer as using the method from the input API causes the cursor to act oddly on macOS, with delayed state changes and sometimes getting the cursor stuck being invisible.

This PR simply makes it not set it on the renderer if running on macOS, which seems to fix these issues.