### PR TITLE
Set up CCache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,23 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qy
-          sudo apt-get install -qy libsdl2-dev # The compilers are already installed on GitHub's runners.
+          sudo apt-get install -qy libsdl2-dev ccache # The compilers are already installed on GitHub's runners.
+
+      - name: Setup CCache
+        run: |
+          eval $(printf 'PATH=/usr/lib/ccache:%s\n' "$PATH" | tee -a "$GITHUB_ENV")
+          cat <<EOF >>"$GITHUB_ENV"
+          CCACHE_MAXSIZE=500M
+          CCACHE_DIR=$HOME/.cache/ccache
+          CCACHE_BASEDIR=$PWD
+          EOF
+      - name: Cache compilation
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.compiler }}-${{ matrix.os }}
+          restore-keys: |
+            ccache-${{ matrix.compiler }}
 
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.
@@ -118,7 +134,23 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qy
-          sudo apt-get install -qy libsdl2-dev libfuse2 # The compilers are already installed on GitHub's runners.
+          sudo apt-get install -qy libsdl2-dev libfuse2 ccache # The compilers are already installed on GitHub's runners.
+
+      - name: Setup CCache
+        run: |
+          eval $(printf 'PATH=/usr/lib/ccache:%s\n' "$PATH" | tee -a "$GITHUB_ENV")
+          cat <<EOF >>"$GITHUB_ENV"
+          CCACHE_MAXSIZE=500M
+          CCACHE_DIR=$HOME/.cache/ccache
+          CCACHE_BASEDIR=$PWD
+          EOF
+      - name: Cache compilation
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-clang-ubuntu-20.04
+          restore-keys: |
+            ccache-clang
 
       - name: Build Mesen (AppImage)
         run: |
@@ -154,7 +186,23 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install sdl2
+          brew install sdl2 ccache
+
+      - name: Setup CCache
+        run: |
+          eval $(printf 'PATH=$(brew --prefix)/opt/ccache/libexec:%s\n' "$PATH" | tee -a "$GITHUB_ENV")
+          cat <<EOF >>"$GITHUB_ENV"
+          CCACHE_MAXSIZE=500M
+          CCACHE_DIR=$HOME/.cache/ccache
+          CCACHE_BASEDIR=$PWD
+          EOF
+      - name: Cache compilation
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.compiler }}-${{ matrix.platform.os }}
+          restore-keys: |
+            ccache-${{ matrix.compiler }}
 
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.


### PR DESCRIPTION
This appears to halve the build time, especially of the slow AoT builds!

(Couldn't really check that the caching works on macOS due to my lack of signing ability, though. But it's symmetrical with the tested Linux builds, so it should work.)