### PR TITLE
UI: Fixed input issues for gamescope

### DIFF
--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -158,7 +158,9 @@ namespace Mesen
 					.UseReactiveUI()
 					.UsePlatformDetect()
 					.With(new Win32PlatformOptions { })
-					.With(new X11PlatformOptions { })
+					.With(new X11PlatformOptions {
+						EnableInputFocusProxy = Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP") == "gamescope",
+					 })
 					.With(new AvaloniaNativePlatformOptions { })
 					.LogToTrace();
 	}


### PR DESCRIPTION
Set Avalonia's EnableInputFocusProxy flag for gamescope (SteamOS / Steam Deck), which fixes issues with the menus