### PR TITLE
UI: Keep track of fractional scrolling (debugger/memory editor)

### DIFF
--- a/UI/Debugger/Controls/CodeScrollBar.axaml.cs
+++ b/UI/Debugger/Controls/CodeScrollBar.axaml.cs
@@ -53,6 +53,8 @@ namespace Mesen.Debugger.Controls
 			set { SetValue(BreakpointBarProperty, value); }
 		}
 
+		private double _scrollAccumulator = 0.0;
+
 		static CodeScrollBar()
 		{
 			ValueProperty.Changed.AddClassHandler<CodeScrollBar>((x, e) => {
@@ -120,7 +122,9 @@ namespace Mesen.Debugger.Controls
 		protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
 		{
 			base.OnPointerWheelChanged(e);
-			Value = Math.Max(0, Math.Min(Maximum, Value - (int)(e.GetDeltaY() * 3)));
+			_scrollAccumulator += e.GetDeltaY() * 3;
+			Value = Math.Max(0, Math.Min(Maximum, Value - (int) _scrollAccumulator));
+			_scrollAccumulator -= (int) _scrollAccumulator;
 		}
 
 		private void IncrementClick(object? sender, RoutedEventArgs e)

--- a/UI/Debugger/Controls/HexEditor.cs
+++ b/UI/Debugger/Controls/HexEditor.cs
@@ -153,6 +153,7 @@ namespace Mesen.Debugger.Controls
 		private float[] _endPositionByByte = Array.Empty<float>();
 		private FontAntialiasing _fontAntialiasing;
 		private Point _pointerPressedPos;
+		private double _scrollAccumulator = 0.0;
 
 		static HexEditor()
 		{
@@ -551,7 +552,9 @@ namespace Mesen.Debugger.Controls
 		protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
 		{
 			base.OnPointerWheelChanged(e);
-			this.TopRow = Math.Min((DataProvider.Length / BytesPerRow) - 1, Math.Max(0, this.TopRow - (int)(e.GetDeltaY() * 3)));
+			_scrollAccumulator += e.GetDeltaY() * 3;
+			this.TopRow = Math.Min((DataProvider.Length / BytesPerRow) - 1, Math.Max(0, this.TopRow - (int) _scrollAccumulator));
+			_scrollAccumulator -= (int) _scrollAccumulator;
 		}
 
 		protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/UI/Debugger/Utilities/CodeViewerSelectionHandler.cs
+++ b/UI/Debugger/Utilities/CodeViewerSelectionHandler.cs
@@ -19,6 +19,7 @@ namespace Mesen.Debugger.Utilities
 		private bool _marginClicked = false;
 		private bool _allowMarginClick = false;
 		private Func<int, int, int> _getRowAddress;
+		private double _scrollAccumulator = 0.0;
 
 		public CodeSegmentInfo? MouseOverSegment { get; private set; }
 		public bool IsMarginClick => _marginClicked;
@@ -114,7 +115,9 @@ namespace Mesen.Debugger.Utilities
 
 		public void Viewer_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
 		{
-			_model.Scroll((int)(-e.GetDeltaY() * 3));
+			_scrollAccumulator += -e.GetDeltaY() * 3;
+			_model.Scroll((int) _scrollAccumulator);
+			_scrollAccumulator -= (int) _scrollAccumulator;
 		}
 
 		private void Viewer_KeyDown(object? sender, KeyEventArgs e)


### PR DESCRIPTION
The code viewer in the debugger and the memory editor scroll line by line. With the way this was currently implemented, these are quite unresponsive and hard to scroll with a trackpad. This was caused by events with a delta of less than ~0.33 being ignored completely, and slowly scrolling with a trackpad only produces such events.

This MR updates the code to keep track of the fractional values and accumulates them for determining the amount to actually scroll. This greatly improves the experience of scrolling the debugger and memory editor with a trackpad.

A quick check with a notched scroll-wheel mouse seems to give no difference in behaviour (as these only give events of exactly 1 or -1, in which case the changed code should not behave differently).