### PR TITLE
MacOS: Add controller support

### DIFF
--- a/MacOS/MacOSGameController.h
+++ b/MacOS/MacOSGameController.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import <GameController/GameController.h>
+#import <CoreHaptics/CoreHaptics.h>
+
 #include <optional>
 
 class Emulator;
@@ -11,6 +16,8 @@ private:
 
 	GCController* _controller;
 	GCExtendedGamepad* _input;
+	CHHapticEngine* _haptics;
+	id<CHHapticPatternPlayer> _player;
 
 	bool _buttonState[24] = {};
 	int16_t _axisState[4] = {};

--- a/MacOS/MacOSGameController.h
+++ b/MacOS/MacOSGameController.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <optional>
+
+class Emulator;
+
+class MacOSGameController
+{
+private:
+	Emulator* _emu;
+
+	GCController* _controller;
+	GCExtendedGamepad* _input;
+
+	bool _buttonState[24] = {};
+	int16_t _axisState[4] = {};
+
+	void HandleDpad(GCControllerDirectionPad* dpad);
+	void HandleThumbstick(GCControllerDirectionPad* stick, int stickNumber);
+
+public:
+	MacOSGameController(Emulator* emu, GCController* controller);
+	~MacOSGameController();
+
+	bool IsGameController(GCController* controller);
+
+	bool IsButtonPressed(int buttonNumber);
+	std::optional<int16_t> GetAxisPosition(int axis);
+
+	void SetForceFeedback(uint16_t magnitude);
+};

--- a/MacOS/MacOSGameController.mm
+++ b/MacOS/MacOSGameController.mm
@@ -1,0 +1,96 @@
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import <GameController/GameController.h>
+
+#include <iostream>
+#include <stdint.h>
+#include <optional>
+
+#include "MacOSGameController.h"
+//The MacOS SDK defines a global function 'Debugger', colliding with Mesen's Debugger class
+//Redefine it temporarily so the headers don't cause compilation errors due to this
+#define Debugger MesenDebugger
+#include "Shared/Emulator.h"
+#include "Shared/EmuSettings.h"
+#undef Debugger
+
+MacOSGameController::MacOSGameController(Emulator* emu, GCController* controller)
+{
+	_emu = emu;
+	_controller = [controller retain];
+	_input = [[_controller extendedGamepad] retain];
+
+	[_input setValueChangedHandler:^ void (GCExtendedGamepad* input, GCControllerElement* element) {
+		if([input buttonA] == element) _buttonState[0] = [((GCControllerButtonInput*) element) isPressed];
+		if([input buttonB] == element) _buttonState[1] = [((GCControllerButtonInput*) element) isPressed];
+		if([input buttonX] == element) _buttonState[2] = [((GCControllerButtonInput*) element) isPressed];
+		if([input buttonY] == element) _buttonState[3] = [((GCControllerButtonInput*) element) isPressed];
+		if([input leftShoulder] == element) _buttonState[4] = [((GCControllerButtonInput*) element) isPressed];
+		if([input rightShoulder] == element) _buttonState[5] = [((GCControllerButtonInput*) element) isPressed];
+		if([input buttonMenu] == element) _buttonState[6] = [((GCControllerButtonInput*) element) isPressed];
+		if([input buttonOptions] == element) _buttonState[7] = [((GCControllerButtonInput*) element) isPressed];
+		if([input dpad] == element) HandleDpad((GCControllerDirectionPad*) element);
+		if([input leftTrigger] == element) _buttonState[12] = [((GCControllerButtonInput*) element) isPressed];
+		if([input rightTrigger] == element) _buttonState[13] = [((GCControllerButtonInput*) element) isPressed];
+		if([input leftThumbstickButton] == element) _buttonState[14] = [((GCControllerButtonInput*) element) isPressed];
+		if([input rightThumbstickButton] == element) _buttonState[15] = [((GCControllerButtonInput*) element) isPressed];
+		if([input leftThumbstick] == element) HandleThumbstick((GCControllerDirectionPad*) element, 0);
+		if([input rightThumbstick] == element) HandleThumbstick((GCControllerDirectionPad*) element, 1);
+	}];
+}
+
+void MacOSGameController::HandleDpad(GCControllerDirectionPad* dpad)
+{
+	_buttonState[8] = [[dpad up] isPressed];
+	_buttonState[9] = [[dpad down] isPressed];
+	_buttonState[10] = [[dpad left] isPressed];
+	_buttonState[11] = [[dpad right] isPressed];
+}
+
+void MacOSGameController::HandleThumbstick(GCControllerDirectionPad* stick, int stickNumber)
+{
+	double deadZoneRatio = _emu->GetSettings()->GetControllerDeadzoneRatio() * 0.4;
+
+	float xAxis = [[stick xAxis] value];
+	float yAxis = [[stick yAxis] value];
+	_buttonState[(stickNumber * 4) + 16] = xAxis > deadZoneRatio;
+	_buttonState[(stickNumber * 4) + 17] = xAxis < -deadZoneRatio;
+	_buttonState[(stickNumber * 4) + 18] = yAxis > deadZoneRatio;
+	_buttonState[(stickNumber * 4) + 19] = yAxis < -deadZoneRatio;
+	_axisState[(stickNumber * 2) + 0] = INT16_MAX * xAxis;
+	_axisState[(stickNumber * 2) + 1] = INT16_MAX * yAxis;
+}
+
+MacOSGameController::~MacOSGameController()
+{
+	[_input setValueChangedHandler:nil];
+	[_input release];
+	[_controller release];
+}
+
+bool MacOSGameController::IsGameController(GCController* controller)
+{
+	return _controller == controller;
+}
+
+bool MacOSGameController::IsButtonPressed(int buttonNumber)
+{
+	if(buttonNumber < 0 || buttonNumber >= 24) {
+		return false;
+	}
+	return _buttonState[buttonNumber];
+}
+
+std::optional<int16_t> MacOSGameController::GetAxisPosition(int axis)
+{
+	axis -= 24;
+	if(axis < 0 || axis >= 4) {
+		return std::nullopt;
+	}
+	return _axisState[axis];
+}
+
+void MacOSGameController::SetForceFeedback(uint16_t magnitude)
+{
+	return;
+}

--- a/MacOS/MacOSKeyManager.h
+++ b/MacOS/MacOSKeyManager.h
@@ -4,12 +4,14 @@
 #include "Shared/Interfaces/IKeyManager.h"
 #include "Shared/KeyDefinitions.h"
 
+class MacOSGameController;
 class Emulator;
 
 class MacOSKeyManager : public IKeyManager
 {
 private:
 	Emulator* _emu;
+	std::vector<shared_ptr<MacOSGameController>> _controllers;
 
 	vector<KeyDefinition> _keyDefinitions;
 	bool _keyState[0x205];
@@ -19,6 +21,8 @@ private:
 	bool _disableAllKeys;
 
 	void* _eventMonitor;
+	void* _connectObserver;
+	void* _disconnectObserver;
 
 	//Mapping of MacOS keycodes to Avalonia keycodes
 	uint16_t _keyCodeMap[128] = {
@@ -43,16 +47,19 @@ public:
 	MacOSKeyManager(Emulator* emu);
 	virtual ~MacOSKeyManager();
 
-	void RefreshState();
-	bool IsKeyPressed(uint16_t key);
-	bool IsMouseButtonPressed(MouseButton button);
-	std::vector<uint16_t> GetPressedKeys();
-	string GetKeyName(uint16_t key);
-	uint16_t GetKeyCode(string keyName);
+	void RefreshState() override;
+	bool IsKeyPressed(uint16_t key) override;
+	optional<int16_t> GetAxisPosition(uint16_t key) override;
+	bool IsMouseButtonPressed(MouseButton button) override;
+	std::vector<uint16_t> GetPressedKeys() override;
+	string GetKeyName(uint16_t key) override;
+	uint16_t GetKeyCode(string keyName) override;
 
-	void UpdateDevices();
-	bool SetKeyState(uint16_t scanCode, bool state);
-	void ResetKeyState();
+	void UpdateDevices() override;
+	bool SetKeyState(uint16_t scanCode, bool state) override;
+	void ResetKeyState() override;
 
-	void SetDisabled(bool disabled);
+	void SetDisabled(bool disabled) override;
+
+	void SetForceFeedback(uint16_t magnitude) override;
 };

--- a/MacOS/MacOSKeyManager.mm
+++ b/MacOS/MacOSKeyManager.mm
@@ -24,10 +24,10 @@ MacOSKeyManager::MacOSKeyManager(Emulator* emu)
 	_keyDefinitions = KeyDefinition::GetSharedKeyDefinitions();
 
 	vector<string> buttonNames = {
-		"A", "B", "X", "Y", "L1", "R1", "Start", "Select", // face buttons, shoulders, others
-		"Up", "Down", "Left", "Right", "L2", "R2", "L3", "R3", // d-pad, triggers, stick press
-		"X+", "X-", "Y+", "Y-", "X2+", "X2-", "Y2+", "Y2-", // left stick, right stick
-		"X", "Y", "X2", "Y2" // stick axis
+		"A", "B", "X", "Y", "L1", "R1", "Start", "Select",
+		"Up", "Down", "Left", "Right", "L2", "R2", "L3", "R3",
+		"X+", "X-", "Y+", "Y-", "X2+", "X2-", "Y2+", "Y2-",
+		"X", "Y", "X2", "Y2"
 	};
 
 	for(int i = 0; i < 20; i++) {
@@ -217,5 +217,7 @@ void MacOSKeyManager::SetDisabled(bool disabled)
 
 void MacOSKeyManager::SetForceFeedback(uint16_t magnitude)
 {
-	return;
+	for(auto& controller : _controllers) {
+		controller->SetForceFeedback(magnitude);
+	}
 }

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -89,11 +89,6 @@
 	  <None Remove="Styles\StartupStyles.xaml" />
 	  <None Remove="Utilities\DipSwitchDefinitions.xml" />
 	</ItemGroup>
-	<PropertyGroup>
-		<RestoreSources>
-			https://nuget-feed-nightly.avaloniaui.net/v3/index.json;https://api.nuget.org/v3/index.json
-		</RestoreSources>
-	</PropertyGroup>
 	<ItemGroup>
 		<TrimmerRootAssembly Include="Mesen" />
 		<TrimmerRootAssembly Include="AvaloniaEdit" />
@@ -103,15 +98,15 @@
 		<TrimmerRootAssembly Include="Dock.Settings" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0045373-beta" />
+    <PackageReference Include="Avalonia" Version="11.1.1" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0045373-beta" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.999-cibuild0045373-beta" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0045373-beta" Condition="'$(OptimizeUi)'!='true'" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0045373-beta" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0045373-beta" />
-    <PackageReference Include="Dock.Avalonia" Version="11.0.10" />
-    <PackageReference Include="Dock.Model.Mvvm" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.1" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.1.1" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.1.1" Condition="'$(OptimizeUi)'!='true'" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.1" />
+    <PackageReference Include="Dock.Avalonia" Version="11.1.0.1" />
+    <PackageReference Include="Dock.Model.Mvvm" Version="11.1.0.1" />
     <PackageReference Include="Dotnet.Bundle" Version="*" />
     <PackageReference Include="ELFSharp" Version="2.17.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -89,6 +89,11 @@
 	  <None Remove="Styles\StartupStyles.xaml" />
 	  <None Remove="Utilities\DipSwitchDefinitions.xml" />
 	</ItemGroup>
+  <PropertyGroup>
+		<RestoreSources>
+			https://nuget-feed-nightly.avaloniaui.net/v3/index.json;https://api.nuget.org/v3/index.json
+		</RestoreSources>
+	</PropertyGroup>
 	<ItemGroup>
 		<TrimmerRootAssembly Include="Mesen" />
 		<TrimmerRootAssembly Include="AvaloniaEdit" />
@@ -98,15 +103,15 @@
 		<TrimmerRootAssembly Include="Dock.Settings" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.1" />
+    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0045373-beta" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.1" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.1.1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.1.1" Condition="'$(OptimizeUi)'!='true'" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.1" />
-    <PackageReference Include="Dock.Avalonia" Version="11.1.0.1" />
-    <PackageReference Include="Dock.Model.Mvvm" Version="11.1.0.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0045373-beta" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.999-cibuild0045373-beta" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0045373-beta" Condition="'$(OptimizeUi)'!='true'" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0045373-beta" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0045373-beta" />
+    <PackageReference Include="Dock.Avalonia" Version="11.0.10" />
+    <PackageReference Include="Dock.Model.Mvvm" Version="11.0.10" />
     <PackageReference Include="Dotnet.Bundle" Version="*" />
     <PackageReference Include="ELFSharp" Version="2.17.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -89,7 +89,7 @@
 	  <None Remove="Styles\StartupStyles.xaml" />
 	  <None Remove="Utilities\DipSwitchDefinitions.xml" />
 	</ItemGroup>
-  <PropertyGroup>
+	<PropertyGroup>
 		<RestoreSources>
 			https://nuget-feed-nightly.avaloniaui.net/v3/index.json;https://api.nuget.org/v3/index.json
 		</RestoreSources>

--- a/makefile
+++ b/makefile
@@ -100,11 +100,11 @@ ifneq ($(STATICLINK),false)
 endif
 
 ifeq ($(MESENOS),osx)
-	LINKOPTIONS += -framework Foundation -framework Cocoa -framework GameController -Wl,-rpath,/opt/local/lib
+	LINKOPTIONS += -framework Foundation -framework Cocoa -framework GameController -framework CoreHaptics -Wl,-rpath,/opt/local/lib
 endif
 
 CXXFLAGS = -fPIC -Wall --std=c++17 $(MESENFLAGS) $(SDL2INC) -I $(realpath ./) -I $(realpath ./Core) -I $(realpath ./Utilities) -I $(realpath ./Sdl) -I $(realpath ./Linux) -I $(realpath ./MacOS)
-OBJCXXFLAGS = $(CXXFLAGS) -framework Foundation -framework Cocoa -framework GameController
+OBJCXXFLAGS = $(CXXFLAGS)
 CFLAGS = -fPIC -Wall $(MESENFLAGS)
 
 OBJFOLDER := obj.$(MESENPLATFORM)

--- a/makefile
+++ b/makefile
@@ -100,11 +100,11 @@ ifneq ($(STATICLINK),false)
 endif
 
 ifeq ($(MESENOS),osx)
-	LINKOPTIONS += -framework Foundation -framework Cocoa -Wl,-rpath,/opt/local/lib
+	LINKOPTIONS += -framework Foundation -framework Cocoa -framework GameController -Wl,-rpath,/opt/local/lib
 endif
 
 CXXFLAGS = -fPIC -Wall --std=c++17 $(MESENFLAGS) $(SDL2INC) -I $(realpath ./) -I $(realpath ./Core) -I $(realpath ./Utilities) -I $(realpath ./Sdl) -I $(realpath ./Linux) -I $(realpath ./MacOS)
-OBJCXXFLAGS = $(CXXFLAGS) -framework Foundation -framework Cocoa
+OBJCXXFLAGS = $(CXXFLAGS) -framework Foundation -framework Cocoa -framework GameController
 CFLAGS = -fPIC -Wall $(MESENFLAGS)
 
 OBJFOLDER := obj.$(MESENPLATFORM)


### PR DESCRIPTION
This PR adds support for controllers to MacOS. The implementation is roughly based on how it works on Linux, with a separate MacOSGameController class.

I marked this as draft for now:
- This makes use of Apple's GCController API, which is a relatively recent API mainly for MFI-gamepads. This likely means it does not have compatibility with gamepads that are not explicitly supported by Apple.
- This is also a recent API as in, that with the API's now used, the minimum MacOS version is bumped to at least 11.0 Big Sur, which might be too recent.
- I am unable to get the current master to run on macOS at all, it compiles fine but gives an error that it can't find 'Avalonia.Vullan' when trying to run with `make run`.
  I'm not sure what happened, but I did notice that my branch for the scrolling-change was made in that brief moment Avalonia was update to 11.1. Maybe something cache related is breaking it now that it was downgraded to 11.0? (but clearing NuGet cache didn't help).
  This MR currently has the update to 11.1 back in so I could test this. I will have to do some more testing to see what is causing it to break with 11.0.
- I haven't extensively tested this with controllers yet, except for a single Xbox One controller. That does seem to work fine, including rumble and stick-readout.

I might look at seeing if the gamepad support from SDL2 can be used instead, which should have way bigger compatibility with gamepads (uses more/different API's I believe) and should run/work on older MacOS as well.