### PR TITLE
3. Add `Core.Test` c++ test project; add tests for `CodeDataLogger`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,10 @@ jobs:
         uses: ./.github/actions/build-sha1-action
 
       - name: Build Mesen
-        run: msbuild -nologo -v:d -clp:ForceConsoleColor -m -p:Configuration=Release -p:Platform=x64 -t:Clean,UI -p:TargetFramework="${{ matrix.platform.targetframework }}"
+        run: msbuild -nologo -v:d -clp:ForceConsoleColor -m -p:Configuration=Release -p:Platform=x64 -t:UI -p:TargetFramework="${{ matrix.platform.targetframework }}"
 
       - name: Publish Mesen
-        run: dotnet publish --no-restore -c Release -p:PublishAot="${{ matrix.platform.aot }}" -p:SelfContained="${{ matrix.platform.aot }}" -p:PublishSingleFile="${{ matrix.platform.singleFile }}" -p:OptimizeUi="true" -p:Platform="Any CPU" -p:TargetFramework="${{ matrix.platform.targetframework }}" -r win-x64 Mesen.sln /p:PublishProfile=UI\Properties\PublishProfiles\Release.pubxml
+        run: dotnet publish UI/UI.csproj --no-restore -c Release -p:PublishAot="${{ matrix.platform.aot }}" -p:SelfContained="${{ matrix.platform.aot }}" -p:PublishSingleFile="${{ matrix.platform.singleFile }}" -p:OptimizeUi="true" -p:Platform="x64" -p:TargetFramework="${{ matrix.platform.targetframework }}" -r win-x64 /p:PublishProfile=Properties\PublishProfiles\Release.pubxml
 
       - name: Upload Mesen
         uses: actions/upload-artifact@v4

--- a/Core.Test/Core.Test.vcxproj
+++ b/Core.Test/Core.Test.vcxproj
@@ -142,7 +142,7 @@
       </Profile>
       <OptimizeReferences>
       </OptimizeReferences>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(SolutionDir)Shared\Libraries\Win-$(PlatformTarget)\;$(SolutionDir)bin\win-$(PlatformTarget)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -176,7 +176,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(SolutionDir)Shared\Libraries\Win-$(PlatformTarget)\;$(SolutionDir)bin\win-$(PlatformTarget)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -208,7 +208,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(SolutionDir)Shared\Libraries\Win-$(PlatformTarget)\;$(SolutionDir)bin\win-$(PlatformTarget)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -240,7 +240,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(SolutionDir)Shared\Libraries\Win-$(PlatformTarget)\;$(SolutionDir)bin\win-$(PlatformTarget)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/Core.Test/Core.Test.vcxproj
+++ b/Core.Test/Core.Test.vcxproj
@@ -25,6 +25,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="TestUtil\TempFile.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Core\Core.vcxproj">
       <Project>{78fef1a1-6df1-4cbb-a373-ae6fa7ce5ce0}</Project>
     </ProjectReference>

--- a/Core.Test/Core.Test.vcxproj
+++ b/Core.Test/Core.Test.vcxproj
@@ -19,6 +19,12 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Debugger\CodeDataLogger.Test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Core\Core.vcxproj">
       <Project>{78fef1a1-6df1-4cbb-a373-ae6fa7ce5ce0}</Project>
     </ProjectReference>
@@ -31,6 +37,9 @@
     <ProjectReference Include="..\Utilities\Utilities.vcxproj">
       <Project>{b5330148-e8c7-46ba-b54e-69be59ea337d}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{20DC996B-90E6-C763-B1CE-B6A48C8391F9}</ProjectGuid>

--- a/Core.Test/Core.Test.vcxproj
+++ b/Core.Test/Core.Test.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="TestUtil\TempFile.Test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestUtil\TempFile.h" />

--- a/Core.Test/Core.Test.vcxproj
+++ b/Core.Test/Core.Test.vcxproj
@@ -22,6 +22,15 @@
     <ProjectReference Include="..\Core\Core.vcxproj">
       <Project>{78fef1a1-6df1-4cbb-a373-ae6fa7ce5ce0}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\Lua\Lua.vcxproj">
+      <Project>{b609e0a0-5050-4871-91d6-e760633bcdd1}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\SevenZip\SevenZip.vcxproj">
+      <Project>{52c4ba3a-e699-4305-b23f-c9083fd07ab6}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Utilities\Utilities.vcxproj">
+      <Project>{b5330148-e8c7-46ba-b54e-69be59ea337d}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{20DC996B-90E6-C763-B1CE-B6A48C8391F9}</ProjectGuid>

--- a/Core.Test/Core.Test.vcxproj
+++ b/Core.Test/Core.Test.vcxproj
@@ -1,0 +1,241 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="PGO Optimize|x64">
+      <Configuration>PGO Optimize</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="PGO Profile|x64">
+      <Configuration>PGO Profile</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.vcxproj">
+      <Project>{78fef1a1-6df1-4cbb-a373-ae6fa7ce5ce0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{20DC996B-90E6-C763-B1CE-B6A48C8391F9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Core</RootNamespace>
+    <ProjectName>Core.Test</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='PGO Profile|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='PGO Optimize|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='PGO Profile|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='PGO Optimize|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(SolutionDir);$(SolutionDir)\Core;$(ProjectDir);$(IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)\bin\win-$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+    <EnableMicrosoftCodeAnalysis>false</EnableMicrosoftCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\bin\win-$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+    <EnableMicrosoftCodeAnalysis>true</EnableMicrosoftCodeAnalysis>
+    <IncludePath>$(SolutionDir);$(SolutionDir)\Core;$(ProjectDir);$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='PGO Profile|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\bin\win-$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+    <EnableMicrosoftCodeAnalysis>false</EnableMicrosoftCodeAnalysis>
+    <IncludePath>$(SolutionDir);$(SolutionDir)\Core;$(ProjectDir);$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='PGO Optimize|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\bin\win-$(PlatformTarget)\PGO Profile\</OutDir>
+    <IntDir>obj\$(Platform)\PGO Profile\</IntDir>
+    <EnableMicrosoftCodeAnalysis>false</EnableMicrosoftCodeAnalysis>
+    <IncludePath>$(SolutionDir);$(SolutionDir)\Core;$(ProjectDir);$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <InlineFunctionExpansion>
+      </InlineFunctionExpansion>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <CallingConvention>Cdecl</CallingConvention>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\Core;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <DisableLanguageExtensions>true</DisableLanguageExtensions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ShowIncludes>
+      </ShowIncludes>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Profile>
+      </Profile>
+      <OptimizeReferences>
+      </OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <OmitFramePointers>true</OmitFramePointers>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\Core;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DisableLanguageExtensions>true</DisableLanguageExtensions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ShowIncludes>
+      </ShowIncludes>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <RuntimeTypeInfo>
+      </RuntimeTypeInfo>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PGO Profile|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>MESENOPTIMIZE;WIN32;NDEBUG;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <OmitFramePointers>true</OmitFramePointers>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\Core;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DisableLanguageExtensions>true</DisableLanguageExtensions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ShowIncludes>
+      </ShowIncludes>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PGO Optimize|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>MESENOPTIMIZE;WIN32;NDEBUG;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <OmitFramePointers>true</OmitFramePointers>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\Core;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DisableLanguageExtensions>true</DisableLanguageExtensions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ShowIncludes>
+      </ShowIncludes>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Core.Test/Core.Test.vcxproj.filters
+++ b/Core.Test/Core.Test.vcxproj.filters
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/Core.Test/Core.Test.vcxproj.filters
+++ b/Core.Test/Core.Test.vcxproj.filters
@@ -1,2 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Debugger">
+      <UniqueIdentifier>{dc955070-0465-4f07-9feb-f62abd34603b}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Debugger\CodeDataLogger.Test.cpp">
+      <Filter>Debugger</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+</Project>
+

--- a/Core.Test/Core.Test.vcxproj.filters
+++ b/Core.Test/Core.Test.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="Debugger\CodeDataLogger.Test.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
+    <ClCompile Include="TestUtil\TempFile.Test.cpp">
+      <Filter>TestUtil</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/Core.Test/Core.Test.vcxproj.filters
+++ b/Core.Test/Core.Test.vcxproj.filters
@@ -7,6 +7,14 @@
     <Filter Include="Debugger">
       <UniqueIdentifier>{dc955070-0465-4f07-9feb-f62abd34603b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="TestUtil">
+      <UniqueIdentifier>{8a68fd58-15c6-4a54-bc57-35547b27c900}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TestUtil\TempFile.h">
+      <Filter>TestUtil</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Debugger\CodeDataLogger.Test.cpp">

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -42,6 +42,86 @@ namespace Test_Debugger
 			TestLogger logger(0x100);
 			Assert::IsNotNull(logger.GetRawData(), L"Raw data buffer should be allocated even with null debugger");
 		}
+		TEST_METHOD(GetCdlData_Destination_Null_Pointer_Does_Not_Crash)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			logger.GetCdlData(0, memSize / 2, nullptr);
+			Assert::IsTrue(true, L"If we reached here, GetCdlData didn't crash");
+		}
+		TEST_METHOD(GetCdlData_Valid_Offset_Valid_Length_Reads_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t copySize = memSize * 2;
+
+			uint8_t output[copySize];
+			std::fill(std::begin(output), std::end(output), 0xEE);
+
+			constexpr uint32_t offset = 10;
+			constexpr uint32_t length = 10;
+
+			logger.GetCdlData(offset, length, output);
+
+			const bool copied = std::all_of(output, output + length,
+				[](uint8_t b) { return b == 0x00; });
+			Assert::IsTrue(copied, L"data not copied");
+			const bool unchanged = std::all_of(output + length, output + copySize,
+				[](uint8_t b) { return b == 0xEE; });
+			Assert::IsTrue(unchanged, L"data copied too far!");
+		}
+		TEST_METHOD(GetCdlData_Valid_Offset_Invalid_Length_Stops)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t copySize = memSize * 2;
+
+			uint8_t output[copySize];
+			std::fill(std::begin(output), std::end(output), 0xEE);
+
+			logger.GetCdlData(10, memSize + 10, output);
+			const bool unchanged = std::all_of(std::begin(output), std::end(output),
+				[](uint8_t b) { return b == 0xEE; });
+			Assert::IsTrue(unchanged, L"memcpy ran off the end");
+		}
+		TEST_METHOD(GetCdlData_Invalid_Offset_Valid_Length_Stops)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t copySize = memSize * 2;
+
+			uint8_t output[copySize];
+			std::fill(std::begin(output), std::end(output), 0xEE);
+
+			logger.GetCdlData(memSize + 10, 10, output);
+			const bool unchanged = std::all_of(std::begin(output), std::end(output),
+				[](uint8_t b) { return b == 0xEE; });
+			Assert::IsTrue(unchanged, L"memcpy ran off the end");
+		}
+		TEST_METHOD(GetCdlData_Invalid_Offset_Invalid_Length_Stops)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t copySize = memSize * 2;
+
+			uint8_t output[copySize];
+			std::fill(std::begin(output), std::end(output), 0xEE);
+
+			logger.GetCdlData(memSize + 10, memSize + 10, output);
+			const bool unchanged = std::all_of(std::begin(output), std::end(output),
+				[](uint8_t b) { return b == 0xEE; });
+			Assert::IsTrue(unchanged, L"memcpy ran off the end");
+		}
+
+		TEST_METHOD(GetCdlData_Can_Read_Last_Byte)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			uint8_t out = 0xEE;
+
+			logger.GetCdlData(memSize - 1, 1, &out);
+			Assert::AreNotEqual((uint8_t)0xEE, out, L"Failed to read the last valid byte of the buffer!");
+		}
 		TEST_METHOD(IsCode_Addr_Outside_Memsize_Clamps)
 		{
 			constexpr uint32_t memSize = 0x100;

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -1,9 +1,13 @@
 #include "pch.h"
 #include "Debugger/CodeDataLogger.h"
 #include "Debugger/Debugger.h"
+#include "TestUtil/TempFile.h"
+
 #include "CppUnitTest.h"
 
 #include <algorithm>
+#include <fstream>
+#include <vector>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -20,6 +24,14 @@ namespace Test_Debugger
 
 	TEST_CLASS(Test_CodeDataLogger)
 	{
+		void AssertRange(CodeDataLogger& logger, uint32_t start, uint32_t end, uint8_t expectedFlag, const wchar_t* message)
+		{
+			auto data = logger.GetRawData();
+			const bool match = std::all_of(data + start, data + end + 1,
+											[expectedFlag](uint8_t b) { return b == expectedFlag; });
+
+			Assert::IsTrue(match, message);
+		}
 
 	public:
 
@@ -203,6 +215,120 @@ namespace Test_Debugger
 			TestLogger logger(memSize);
 			constexpr uint32_t dangerousAddr = 0xFFFFFFFF;
 			Assert::IsFalse(logger.IsSubEntryPoint(dangerousAddr), L"crashed or returned garbage for high address");
+		}
+
+		TEST_METHOD(LoadCdlFile_NonExistentFile_ShouldReturnFalse)
+		{
+			TestLogger logger(0x100, 0);
+			Assert::IsFalse(logger.LoadCdlFile("does_not_exist.cdl", true), L"Should fail for non-existent file");
+		}
+
+		TEST_METHOD(LoadCdlFile_File_Too_Small_Has_Empty_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize, 0x11111111);
+			TempFile testFile("too_small.cdl");
+
+			{
+				ofstream outFile(testFile, std::ios::binary | std::ios::trunc);
+				outFile.write("123", 3);
+				outFile.close();
+			}
+
+			Assert::IsFalse(logger.LoadCdlFile(testFile, true), L"Should reject truncated file");
+			AssertRange(logger, 0, memSize - 1, 0, L"File too small: All cdl file data should be set back to zeros.");
+		}
+
+		TEST_METHOD(LoadCdlFile_AutoResetCdl_False_CRC_Match_Loads_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			constexpr uint32_t romCrc = 0x11111111;
+			TempFile testFile("load_crc_match_no_reset.cdl");
+			constexpr bool AutoResetCdl = false;
+
+			TestLogger logger(memSize, romCrc);
+			logger.MarkBytesAs(0, 10, CdlFlags::Code);
+			logger.MarkBytesAs(11, 20, CdlFlags::Data);
+			Assert::IsTrue(logger.SaveCdlFile(testFile), L"Failed to save CDL file");
+
+			TestLogger reader(memSize, romCrc);
+			Assert::IsTrue(reader.LoadCdlFile(testFile, AutoResetCdl), L"Failed to load CDL file");
+			AssertRange(reader, 0, 10, CdlFlags::Code, L"Range 0-10 should be Code");
+			AssertRange(reader, 11, 20, CdlFlags::Data, L"Range 11-20 should be Data");
+		}
+
+		TEST_METHOD(LoadCdlFile_AutoResetCdl_True_CRC_Match_Loads_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			constexpr uint32_t romCrc = 0x11111111;
+			TempFile testFile("load_crc_match_with_reset.cdl");
+			constexpr bool AutoResetCdl = true;
+
+			TestLogger logger(memSize, romCrc);
+			logger.MarkBytesAs(0, 10, CdlFlags::Code);
+			logger.MarkBytesAs(11, 20, CdlFlags::Data);
+			Assert::IsTrue(logger.SaveCdlFile(testFile), L"Failed to save CDL file");
+
+			TestLogger reader(memSize, romCrc);
+			Assert::IsTrue(reader.LoadCdlFile(testFile, AutoResetCdl), L"Failed to load CDL file");
+			AssertRange(reader, 0, 10, CdlFlags::Code, L"Range 0-10 should be Code");
+			AssertRange(reader, 11, 20, CdlFlags::Data, L"Range 11-20 should be Data");
+		}
+
+		TEST_METHOD(LoadCdlFile_AutoResetCdl_False_CRC_Mismatch_Loads_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			constexpr uint32_t romCrc = 0x11111111;
+			TempFile testFile("load_crc_bad_no_reset.cdl");
+			constexpr bool AutoResetCdl = false;
+
+			TestLogger logger(memSize, romCrc);
+			logger.MarkBytesAs(0, 10, CdlFlags::Code);
+			logger.MarkBytesAs(11, 20, CdlFlags::Data);
+			Assert::IsTrue(logger.SaveCdlFile(testFile), L"Failed to save CDL file");
+
+			constexpr uint32_t badCrc = 0x0BAD0BAD;
+			TestLogger reader(memSize, badCrc);
+			Assert::IsTrue(reader.LoadCdlFile(testFile, AutoResetCdl), L"Failed to load CDL file");
+			AssertRange(reader, 0, 10, CdlFlags::Code, L"Range 0-10 should be Code");
+			AssertRange(reader, 11, 20, CdlFlags::Data, L"Range 11-20 should be Data");
+		}
+
+		TEST_METHOD(LoadCdlFile_AutoResetCdl_True_CRC_Mismatch_Zeros_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			constexpr uint32_t romCrc = 0x11111111;
+			TempFile testFile("load_crc_bad_with_reset.cdl");
+			constexpr bool AutoResetCdl = true;
+
+			TestLogger logger(memSize, romCrc);
+			logger.MarkBytesAs(0, 10, CdlFlags::Code);
+			logger.MarkBytesAs(11, 20, CdlFlags::Data);
+			Assert::IsTrue(logger.SaveCdlFile(testFile), L"Failed to save CDL file");
+
+			constexpr uint32_t badCrc = 0x0BAD0BAD;
+			TestLogger reader(memSize, badCrc);
+			Assert::IsFalse(reader.LoadCdlFile(testFile, AutoResetCdl), L"LoadCdlFile() should return false");
+
+			AssertRange(reader, 0, memSize - 1, 0, L"CRC Mismatch and AudoReset True: All cdl file data should be set back to zeros.");
+		}
+
+		TEST_METHOD(LoadCdlFile_Legacy_Format_Loads)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize, 0x11111111);
+			TempFile testFile("legacy.cdl");
+
+			// Create a file with no header, just raw data
+			{
+				ofstream outFile(testFile, std::ios::binary);
+				vector<uint8_t> rawData(memSize, 0xCC);
+				outFile.write((char*)rawData.data(), memSize);
+				outFile.close();
+			}
+
+			Assert::IsTrue(logger.LoadCdlFile(testFile, true), L"Could not load legacy cdl file");
+			Assert::AreEqual((uint8_t)0xCC, logger.GetRawData()[0], L"Legacy data mismatch");
 		}
 
 		TEST_METHOD(MarkBytesAs_End_Greater_Than_Memsize_Clamps)

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -155,6 +155,26 @@ namespace Test_Debugger
 			logger.GetFunctions(nullptr, 10);
 		}
 
+		TEST_METHOD(GetStatistics_Returns_Correct_Numbers)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+
+			constexpr uint32_t codeStart = 0;
+			constexpr uint32_t codeEnd = 10;
+			logger.MarkBytesAs(codeStart, codeEnd, CdlFlags::Code);
+
+			constexpr uint32_t dataStart = 20;
+			constexpr uint32_t dataEnd = 32;
+			logger.MarkBytesAs(dataStart, dataEnd, CdlFlags::Data);
+
+			const CdlStatistics stats = logger.GetStatistics();
+
+			Assert::AreEqual(codeEnd - codeStart + 1, stats.CodeBytes, L"Code stats incorrect");
+			Assert::AreEqual(dataEnd - dataStart + 1, stats.DataBytes, L"Data stats incorrect");
+			Assert::AreEqual(memSize, stats.TotalBytes, L"Total bytes incorrect");
+		}
+
 		TEST_METHOD(IsCode_Addr_Outside_Memsize_Clamps)
 		{
 			constexpr uint32_t memSize = 0x100;

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -222,5 +222,11 @@ namespace Test_Debugger
 			logger.SetCdlData(nullptr, 1);
 			Assert::IsTrue(true, L"SetCdlData did not crash.");
 		}
+		TEST_METHOD(StripData_Null_Rombuffer_Does_Not_Crash)
+		{
+			TestLogger logger(0x100);
+			logger.StripData(nullptr, CdlStripOption::StripUnused);
+			Assert::IsTrue(true, L"StripData did not crash.");
+		}
 	};
 }

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -185,6 +185,21 @@ namespace Test_Debugger
 			Assert::IsFalse(logger.IsSubEntryPoint(dangerousAddr), L"crashed or returned garbage for high address");
 		}
 
+		TEST_METHOD(MarkBytesAs_End_Greater_Than_Memsize_Clamps)
+		{
+			constexpr uint32_t memSize = 0x100;
+			constexpr uint32_t endTooFar = memSize + 0x100;
+			constexpr uint32_t start = 90;
+			Assert::IsTrue(start + endTooFar > memSize, L"Incorrect test setup: MarkBytes outside of memSize.");
+
+			TestLogger logger(memSize);
+			logger.MarkBytesAs(start, endTooFar, CdlFlags::Code);
+
+			Assert::AreEqual((uint8_t)CdlFlags::Code, logger.GetFlags(start), L"Start of buffer should be marked safely");
+			Assert::AreEqual((uint8_t)CdlFlags::Code, logger.GetFlags(memSize - 1), L"End of buffer should be marked safely");
+			Assert::AreEqual((uint8_t)0, logger.GetFlags(memSize), L"Data past end should not be modified");
+		}
+
 		TEST_METHOD(SetCdlData_Length_Greater_Than_Memsize_Does_Not_Crash)
 		{
 			constexpr uint32_t memSize = 0x100;

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -71,5 +71,28 @@ namespace Test_Debugger
 			constexpr uint32_t dangerousAddr = 0xFFFFFFFF;
 			Assert::IsFalse(logger.IsSubEntryPoint(dangerousAddr), L"crashed or returned garbage for high address");
 		}
+
+		TEST_METHOD(SetCdlData_Length_Greater_Than_Memsize_Does_Not_Crash)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+
+			uint8_t sourceData[] = { 0xAA, 0xBB, 0xCC, 0xDD };
+
+			logger.SetCdlData(sourceData, 0xFFFFFFFF);
+			const uint8_t* internalData = logger.GetRawData();
+			for(uint32_t i = 0; i < memSize; i++) {
+				Assert::AreEqual((uint8_t)0, internalData[i], L"Data was modified despite invalid length");
+			}
+		}
+
+		TEST_METHOD(SetCdlData_Null_Pointer_Does_Not_Crash)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+
+			logger.SetCdlData(nullptr, 1);
+			Assert::IsTrue(true, L"SetCdlData did not crash.");
+		}
 	};
 }

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -122,6 +122,15 @@ namespace Test_Debugger
 			logger.GetCdlData(memSize - 1, 1, &out);
 			Assert::AreNotEqual((uint8_t)0xEE, out, L"Failed to read the last valid byte of the buffer!");
 		}
+		TEST_METHOD(GetFlags_Addr_Outside_Memsize_Returns)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t outOfBoundsAddr = 0xFFFFFFFF;
+			Assert::IsTrue(outOfBoundsAddr > memSize);
+			Assert::AreEqual((uint8_t)0, logger.GetFlags(outOfBoundsAddr), L"GetFlags should return 0 for OOB");
+		}
+
 		TEST_METHOD(IsCode_Addr_Outside_Memsize_Clamps)
 		{
 			constexpr uint32_t memSize = 0x100;

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -188,6 +188,31 @@ namespace Test_Debugger
 			Assert::AreEqual(memSize, stats.TotalBytes, L"Total bytes incorrect");
 		}
 
+		TEST_METHOD(Integration_MarkBytes_Then_SaveFile_Then_LoadFile_Works)
+		{
+			constexpr uint32_t memSize = 0x10;
+			constexpr uint32_t romCrc = 0x11111111;
+			TempFile testFile("integration.cdl");
+			TestLogger logger(memSize, romCrc);
+
+			logger.MarkBytesAs(0, 0, CdlFlags::Code);
+			logger.MarkBytesAs(1, 1, CdlFlags::Data);
+			logger.MarkBytesAs(2, 2, CdlFlags::JumpTarget);
+			logger.MarkBytesAs(3, 3, CdlFlags::SubEntryPoint);
+			logger.MarkBytesAs(4, 4, CdlFlags::Code | CdlFlags::JumpTarget);
+
+			Assert::IsTrue(logger.SaveCdlFile(testFile), L"Could not save file");
+
+			TestLogger reader(memSize, romCrc);
+			Assert::IsTrue(reader.LoadCdlFile(testFile, true), L"Could not read file");
+
+			Assert::IsTrue(reader.IsCode(0), L"Flag lost: Code");
+			Assert::IsTrue(reader.IsData(1), L"Flag lost: Data");
+			Assert::IsTrue(reader.IsJumpTarget(2), L"Flag lost: JumpTarget");
+			Assert::IsTrue(reader.IsSubEntryPoint(3), L"Flag lost: SubEntryPoint");
+			Assert::AreEqual((uint8_t)(CdlFlags::Code | CdlFlags::JumpTarget), reader.GetFlags(4), L"Combined flags mismatch");
+		}
+
 		TEST_METHOD(IsCode_Addr_Outside_Memsize_Clamps)
 		{
 			constexpr uint32_t memSize = 0x100;

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -1,0 +1,46 @@
+#include "pch.h"
+#include "Debugger/CodeDataLogger.h"
+#include "Debugger/Debugger.h"
+#include "CppUnitTest.h"
+
+#include <algorithm>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace Test_Debugger
+{
+	class TestLogger : public CodeDataLogger
+	{
+	public:
+		TestLogger(uint32_t memSize = 0x100, uint32_t romCrc = 0)
+			: CodeDataLogger(nullptr, MemoryType::SnesPrgRom, memSize, CpuType::Snes, romCrc)
+		{
+		}
+	};
+
+	TEST_CLASS(Test_CodeDataLogger)
+	{
+
+	public:
+
+		TEST_METHOD(Constructor_Memsize_Large_Does_Not_Crash)
+		{
+			constexpr uint32_t largeSize = 0xFFFFFFFF;
+			TestLogger logger(largeSize);
+			Assert::IsNotNull(logger.GetRawData(), L"Data not set");
+		}
+
+		TEST_METHOD(Constructor_Memsize_Zero_Does_Not_Crash)
+		{
+			constexpr uint32_t zeroSize = 0;
+			TestLogger logger(zeroSize);
+			Assert::IsNotNull(logger.GetRawData(), L"Data not set");
+		}
+
+		TEST_METHOD(Constructor_Null_Debugger_Does_Not_Crash)
+		{
+			TestLogger logger(0x100);
+			Assert::IsNotNull(logger.GetRawData(), L"Raw data buffer should be allocated even with null debugger");
+		}
+	};
+}

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -20,6 +20,7 @@ namespace Test_Debugger
 			: CodeDataLogger(nullptr, MemoryType::SnesPrgRom, memSize, CpuType::Snes, romCrc)
 		{
 		}
+		static const uint32_t PublicHeaderSize = HeaderSize;
 	};
 
 	TEST_CLASS(Test_CodeDataLogger)
@@ -344,6 +345,40 @@ namespace Test_Debugger
 			Assert::AreEqual((uint8_t)CdlFlags::Code, logger.GetFlags(start), L"Start of buffer should be marked safely");
 			Assert::AreEqual((uint8_t)CdlFlags::Code, logger.GetFlags(memSize - 1), L"End of buffer should be marked safely");
 			Assert::AreEqual((uint8_t)0, logger.GetFlags(memSize), L"Data past end should not be modified");
+		}
+
+		TEST_METHOD(SaveCdlFile_Writes_Expected_Format)
+		{
+			constexpr uint32_t memSize = 0x10;
+			constexpr uint32_t romCrc = 0x11111111;
+			TempFile testFile("save_test.cdl");
+
+			TestLogger logger(memSize, romCrc);
+			logger.MarkBytesAs(0, 0x07, CdlFlags::Code);
+			logger.MarkBytesAs(0x08, 0x0F, CdlFlags::Data);
+			Assert::IsTrue(logger.SaveCdlFile(testFile), L"SaveCdlFile returned false");
+
+			std::ifstream inFile(testFile, std::ios::binary);
+			std::vector<uint8_t> readData((std::istreambuf_iterator<char>(inFile)), std::istreambuf_iterator<char>());
+			inFile.close();
+
+			constexpr size_t expectedSize = TestLogger::PublicHeaderSize + memSize;
+			Assert::AreEqual(expectedSize, readData.size(), L"Saved file size mismatch");
+
+			Assert::AreEqual(0, memcmp(readData.data(), "CDLv2", 5), L"Header mismatch");
+
+			const uint32_t savedCrc = readData[5] |
+				(readData[6] << 8) |
+				(readData[7] << 16) |
+				(readData[8] << 24);
+
+			Assert::AreEqual(romCrc, savedCrc, L"CRC32 in file mismatch");
+
+			const uint8_t* actualData = logger.GetRawData();
+			for(uint32_t i = 0; i < memSize; i++) {
+				Assert::AreEqual(actualData[i], readData[TestLogger::PublicHeaderSize + i],
+					L"Payload data mismatch at index");
+			}
 		}
 
 		TEST_METHOD(SetCdlData_Length_Greater_Than_Memsize_Does_Not_Crash)

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -131,6 +131,30 @@ namespace Test_Debugger
 			Assert::AreEqual((uint8_t)0, logger.GetFlags(outOfBoundsAddr), L"GetFlags should return 0 for OOB");
 		}
 
+		TEST_METHOD(GetFunctions_Returns_Data)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			logger.MarkBytesAs(0, 49, CdlFlags::SubEntryPoint);
+
+			struct
+			{
+				uint32_t list[10];
+			} data;
+
+			const uint32_t count = logger.GetFunctions(data.list, 10);
+			Assert::AreEqual((uint32_t)10, count, L"Count should be capped at maxSize");
+			Assert::AreEqual((uint32_t)0, data.list[0], L"First entry should be address 0");
+			Assert::AreEqual((uint32_t)9, data.list[9], L"Last entry should be address 9");
+		}
+
+		TEST_METHOD(GetFunctions_NullBuffer_Does_Not_Crash)
+		{
+			TestLogger logger(0x100);
+			logger.MarkBytesAs(0, 0, CdlFlags::SubEntryPoint);
+			logger.GetFunctions(nullptr, 10);
+		}
+
 		TEST_METHOD(IsCode_Addr_Outside_Memsize_Clamps)
 		{
 			constexpr uint32_t memSize = 0x100;

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -42,5 +42,34 @@ namespace Test_Debugger
 			TestLogger logger(0x100);
 			Assert::IsNotNull(logger.GetRawData(), L"Raw data buffer should be allocated even with null debugger");
 		}
+		TEST_METHOD(IsCode_Addr_Outside_Memsize_Clamps)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t dangerousAddr = 0xFFFFFFFF;
+			Assert::IsFalse(logger.IsCode(dangerousAddr), L"crashed or returned garbage for high address");
+		}
+		TEST_METHOD(IsData_Addr_Outside_Memsize_Clamps)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t dangerousAddr = 0xFFFFFFFF;
+			Assert::IsFalse(logger.IsData(dangerousAddr), L"crashed or returned garbage for high address");
+		}
+
+		TEST_METHOD(IsJumpTarget_Addr_Outside_Memsize_Clamps)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t dangerousAddr = 0xFFFFFFFF;
+			Assert::IsFalse(logger.IsJumpTarget(dangerousAddr), L"crashed or returned garbage for high address");
+		}
+		TEST_METHOD(IsSubEntryPoint_Addr_Outside_Memsize_Clamps)
+		{
+			constexpr uint32_t memSize = 0x100;
+			TestLogger logger(memSize);
+			constexpr uint32_t dangerousAddr = 0xFFFFFFFF;
+			Assert::IsFalse(logger.IsSubEntryPoint(dangerousAddr), L"crashed or returned garbage for high address");
+		}
 	};
 }

--- a/Core.Test/Debugger/CodeDataLogger.Test.cpp
+++ b/Core.Test/Debugger/CodeDataLogger.Test.cpp
@@ -20,7 +20,9 @@ namespace Test_Debugger
 			: CodeDataLogger(nullptr, MemoryType::SnesPrgRom, memSize, CpuType::Snes, romCrc)
 		{
 		}
+
 		static const uint32_t PublicHeaderSize = HeaderSize;
+		static constexpr std::string_view PublicHeader = CdlHeader;
 	};
 
 	TEST_CLASS(Test_CodeDataLogger)
@@ -55,6 +57,7 @@ namespace Test_Debugger
 			TestLogger logger(0x100);
 			Assert::IsNotNull(logger.GetRawData(), L"Raw data buffer should be allocated even with null debugger");
 		}
+
 		TEST_METHOD(GetCdlData_Destination_Null_Pointer_Does_Not_Crash)
 		{
 			constexpr uint32_t memSize = 0x100;
@@ -390,7 +393,7 @@ namespace Test_Debugger
 			constexpr size_t expectedSize = TestLogger::PublicHeaderSize + memSize;
 			Assert::AreEqual(expectedSize, readData.size(), L"Saved file size mismatch");
 
-			Assert::AreEqual(0, memcmp(readData.data(), "CDLv2", 5), L"Header mismatch");
+			Assert::AreEqual(0, memcmp(readData.data(), TestLogger::PublicHeader.data(), TestLogger::PublicHeader.length()), L"Header mismatch");
 
 			const uint32_t savedCrc = readData[5] |
 				(readData[6] << 8) |

--- a/Core.Test/TestUtil/TempFile.Test.cpp
+++ b/Core.Test/TestUtil/TempFile.Test.cpp
@@ -1,0 +1,101 @@
+#include "pch.h"
+#include <fstream>
+#include <filesystem>
+#include "CppUnitTest.h"
+#include "TempFile.h"
+
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+namespace fs = std::filesystem;
+
+namespace Test_TestUtil
+{
+
+	TEST_CLASS(Test_TempFile)
+	{
+	public:
+		TEST_METHOD(Constructor_Creates_File)
+		{
+			std::string filename = "creation_test.cdl";
+			TempFile temp(filename);
+			std::string pathStr = temp.str();
+			Assert::IsFalse(pathStr.empty(), L"Path should not be empty");
+
+			fs::path p(pathStr);
+			Assert::AreEqual(filename, p.filename().string(), L"Filename mismatch");
+		}
+
+		TEST_METHOD(Destructor_Deletes_File)
+		{
+			fs::path filePath;
+
+			// use brackets for scope to trigger destructor
+			{
+				TempFile temp("cleanup_test.txt");
+				filePath = temp.FilePath;
+
+				// Manually create the file so there is something to delete
+				std::ofstream ofs(filePath);
+				ofs << "test data";
+				ofs.close();
+
+				Assert::IsTrue(fs::exists(filePath), L"File should exist before destructor runs");
+			}
+			Assert::IsFalse(fs::exists(filePath), L"File should have been deleted by destructor");
+		}
+
+		TEST_METHOD(Destructor_Handles_Missing_File)
+		{
+			fs::path filePath;
+
+			{
+				TempFile temp("never_created.txt");
+				filePath = temp.FilePath;
+				Assert::IsFalse(fs::exists(filePath), L"File should not exist");
+			}
+			Assert::IsFalse(fs::exists(filePath), L"File should not exist");
+			Assert::IsTrue(true, L"Destructor handled non-existent file without crashing");
+		}
+		TEST_METHOD(Move_Transfers_Ownership)
+		{
+			fs::path originalPath;
+			{
+				TempFile source("move_test.txt");
+				originalPath = source.FilePath;
+
+				TempFile destination(std::move(source));
+
+				Assert::AreEqual(originalPath.string(), destination.str(), L"destination should now own the path");
+				Assert::IsTrue(source.FilePath.empty(), L"source path should be cleared after move");
+			}
+			Assert::IsFalse(fs::exists(originalPath), L"File should be gone after moved-to object dies");
+		}
+
+		TEST_METHOD(Move_Assignment_Transfers_And_Clears_Source)
+		{
+			fs::path originalPath;
+			{
+				TempFile source("move_assign_test.txt");
+				TempFile destination("dummy.txt");
+				originalPath = source.FilePath;
+
+				// This triggers: TempFile& operator=(TempFile&& other)
+				destination = std::move(source);
+
+				Assert::AreEqual(originalPath.string(), destination.str());
+				Assert::IsTrue(source.FilePath.empty(), L"Source not cleared after assignment");
+			}
+			Assert::IsFalse(fs::exists(originalPath));
+		}
+
+		TEST_METHOD(Move_Assignment_Self_Assignment_Safety)
+		{
+			TempFile source("self.txt");
+			std::string pathBefore = source.str();
+
+			source = std::move(source);
+
+			Assert::AreEqual(pathBefore, source.str(), L"Self-assignment cleared the path!");
+		}
+	};
+}

--- a/Core.Test/TestUtil/TempFile.h
+++ b/Core.Test/TestUtil/TempFile.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <string>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+// Helper function - make it easy to create and clean up temp files on disk.
+struct TempFile
+{
+	fs::path FilePath;
+
+	/**
+	 * Create a temporary file in the OS temp directory.
+	 * 
+	 * TempFiles are automatically deleted once the object goes out of scope,
+	 * so you can easily create TempFiles for testing and don't need to worry about leaving files around.
+	 * e.g.
+	 * 
+	 * {
+	 *		TempFile yourfile("name.txt");
+	 *    // your code here...
+	 * }
+	 * // TempFile automatically deleted when scope exits the {} brackets.
+	 *
+	 * @param filename Filename to use, including extension if desired.
+	 */
+	TempFile(std::string filename)
+	{
+		FilePath = fs::temp_directory_path() / filename;
+	}
+
+	~TempFile()
+	{
+		std::error_code ec;
+		fs::remove(FilePath, ec);
+	}
+
+	TempFile(const TempFile&) = delete;
+	TempFile& operator=(const TempFile&) = delete;
+	TempFile(TempFile&& other) noexcept : FilePath(std::move(other.FilePath))
+	{
+		other.FilePath.clear(); // Ensure the old object doesn't delete the file
+	}
+	TempFile& operator=(TempFile&& other) noexcept
+	{
+		if(this != &other) {
+			FilePath = std::move(other.FilePath);
+			other.FilePath.clear();
+		}
+		return *this;
+	}
+
+	std::string str() const { return FilePath.string(); }
+	operator std::string() const { return FilePath.string(); }
+	operator const fs::path& () const { return FilePath; }
+};

--- a/Core.Test/pch.cpp
+++ b/Core.Test/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/Core.Test/pch.h
+++ b/Core.Test/pch.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "CppUnitTest.h"
+
+#include <algorithm>

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -30,7 +30,9 @@ CodeDataLogger::~CodeDataLogger()
 
 void CodeDataLogger::Reset()
 {
-	memset(_cdlData, 0, _memSize);
+	if(_cdlData) {
+		memset(_cdlData, 0, _memSize);
+	}
 }
 
 uint8_t* CodeDataLogger::GetRawData()

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -127,21 +127,35 @@ CdlStatistics CodeDataLogger::GetStatistics()
 
 bool CodeDataLogger::IsCode(uint32_t absoluteAddr)
 {
+	if(absoluteAddr >= _memSize) {
+		return false;
+	}
 	return (_cdlData[absoluteAddr] & CdlFlags::Code) != 0;
 }
 
 bool CodeDataLogger::IsJumpTarget(uint32_t absoluteAddr)
 {
+	if(absoluteAddr >= _memSize) {
+		return false;
+	}
+
 	return (_cdlData[absoluteAddr] & CdlFlags::JumpTarget) != 0;
 }
 
 bool CodeDataLogger::IsSubEntryPoint(uint32_t absoluteAddr)
 {
+	if(absoluteAddr >= _memSize) {
+		return false;
+	}
+
 	return (_cdlData[absoluteAddr] & CdlFlags::SubEntryPoint) != 0;
 }
 
 bool CodeDataLogger::IsData(uint32_t absoluteAddr)
 {
+	if(absoluteAddr >= _memSize) {
+		return false;
+	}
 	return (_cdlData[absoluteAddr] & CdlFlags::Data) != 0;
 }
 

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -161,7 +161,7 @@ bool CodeDataLogger::IsData(uint32_t absoluteAddr)
 
 void CodeDataLogger::SetCdlData(uint8_t *cdlData, uint32_t length)
 {
-	if(length <= _memSize) {
+	if(cdlData && length <= _memSize) {
 		memcpy(_cdlData, cdlData, length);
 	}
 }

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -118,7 +118,7 @@ CdlStatistics CodeDataLogger::GetStatistics()
 	uint32_t dataSize = 0;
 	uint32_t bothSize = 0;
 
-	for(int i = 0, len = _memSize; i < len; i++) {
+	for(uint32_t i = 0, len = _memSize; i < len; i++) {
 		uint32_t isCode = (uint32_t)(_cdlData[i] & CdlFlags::Code);
 		uint32_t isData = (uint32_t)(_cdlData[i] & CdlFlags::Data) >> 1;
 		codeSize += isCode;

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -168,7 +168,9 @@ void CodeDataLogger::SetCdlData(uint8_t *cdlData, uint32_t length)
 
 void CodeDataLogger::GetCdlData(uint32_t offset, uint32_t length, uint8_t *cdlData)
 {
-	memcpy(cdlData, _cdlData + offset, length);
+	if(cdlData && (offset + length <= _memSize)) {
+		memcpy(cdlData, _cdlData + offset, length);
+	}
 }
 
 uint8_t CodeDataLogger::GetFlags(uint32_t addr)

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -216,6 +216,10 @@ void CodeDataLogger::MarkBytesAs(uint32_t start, uint32_t end, uint8_t flags)
 
 void CodeDataLogger::StripData(uint8_t* romBuffer, CdlStripOption flag)
 {
+	if(!romBuffer) {
+		return;
+	}
+
 	if(flag == CdlStripOption::StripUnused) {
 		for(uint32_t i = 0; i < _memSize; i++) {
 			if(_cdlData[i] == 0) {

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -204,6 +204,11 @@ uint32_t CodeDataLogger::GetFunctions(uint32_t functions[], uint32_t maxSize)
 
 void CodeDataLogger::MarkBytesAs(uint32_t start, uint32_t end, uint8_t flags)
 {
+	if(end >= _memSize) {
+		MessageManager::Log("[Warning] end >= _memSize; capping CDL bytes");
+		end = _memSize - 1;
+	}
+
 	for(uint32_t i = start; i <= end; i++) {
 		_cdlData[i] = (_cdlData[i] & 0xFC) | (int)flags;
 	}

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -50,6 +50,16 @@ MemoryType CodeDataLogger::GetMemoryType()
 	return _memType;
 }
 
+/**
+ * Read a CDL file and load contents into memory.
+ *
+ * Checks the 4-byte CRC32 value of the CDL file against the expected CRC32 for the current ROM. If checksums do not match, clears all CDL data and starts over from zero.
+ *
+ * @param cdlFilepath Valid path to the file to read.
+ * @param autoResetCdl If false: ignore mismatched CRC and load CDL data even if checksums do not match.
+ *
+ * @return Returns true if the file was successfully read and loaded, and false otherwise.
+ */
 bool CodeDataLogger::LoadCdlFile(string cdlFilepath, bool autoResetCdl)
 {
 	VirtualFile cdlFile = cdlFilepath;
@@ -65,6 +75,7 @@ bool CodeDataLogger::LoadCdlFile(string cdlFilepath, bool autoResetCdl)
 				if((!autoResetCdl || savedCrc == _romCrc32) && fileSize >= _memSize + CodeDataLogger::HeaderSize) {
 					memcpy(_cdlData, cdlData.data() + CodeDataLogger::HeaderSize, _memSize);
 					InternalLoadCdlFile(cdlData.data() + CodeDataLogger::HeaderSize, (uint32_t)cdlData.size() - CodeDataLogger::HeaderSize);
+					return true;
 				}
 			} else {
 				MessageManager::Log("[Warning] CDL file doesn't contain header/CRC and may be incompatible.");
@@ -72,9 +83,8 @@ bool CodeDataLogger::LoadCdlFile(string cdlFilepath, bool autoResetCdl)
 				//Older CRC-less CDL file, use as-is without checking CRC to avoid data loss
 				memcpy(_cdlData, cdlData.data(), _memSize);
 				InternalLoadCdlFile(cdlData.data(), (uint32_t)cdlData.size());
+				return true;
 			}
-			
-			return true;
 		}
 	}
 	return false;

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -70,7 +70,7 @@ bool CodeDataLogger::LoadCdlFile(string cdlFilepath, bool autoResetCdl)
 		if(fileSize >= _memSize && fileSize >= CodeDataLogger::HeaderSize) {
 			Reset();
 
-			if(memcmp(cdlData.data(), "CDLv2", 5) == 0) {
+			if(memcmp(cdlData.data(), CodeDataLogger::CdlHeader.data(), CodeDataLogger::CdlHeader.length()) == 0) {
 				uint32_t savedCrc = cdlData[5] | (cdlData[6] << 8) | (cdlData[7] << 16) | (cdlData[8] << 24);
 				if((!autoResetCdl || savedCrc == _romCrc32) && fileSize >= _memSize + CodeDataLogger::HeaderSize) {
 					memcpy(_cdlData, cdlData.data() + CodeDataLogger::HeaderSize, _memSize);
@@ -94,7 +94,7 @@ bool CodeDataLogger::SaveCdlFile(string cdlFilepath)
 {
 	ofstream cdlFile(cdlFilepath, ios::out | ios::binary);
 	if(cdlFile) {
-		cdlFile.write("CDLv2", 5);
+		cdlFile.write(CodeDataLogger::CdlHeader.data(), CodeDataLogger::CdlHeader.length());
 		cdlFile.put(_romCrc32 & 0xFF);
 		cdlFile.put((_romCrc32 >> 8) & 0xFF);
 		cdlFile.put((_romCrc32 >> 16) & 0xFF);

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -175,6 +175,10 @@ void CodeDataLogger::GetCdlData(uint32_t offset, uint32_t length, uint8_t *cdlDa
 
 uint8_t CodeDataLogger::GetFlags(uint32_t addr)
 {
+	if(addr >= _memSize) {
+		return 0;
+	}
+
 	return _cdlData[addr];
 }
 

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -184,6 +184,10 @@ uint8_t CodeDataLogger::GetFlags(uint32_t addr)
 
 uint32_t CodeDataLogger::GetFunctions(uint32_t functions[], uint32_t maxSize)
 {
+	if(!functions) {
+		return 0;
+	}
+
 	uint32_t count = 0;
 	for(int i = 0, len = _memSize; i < len; i++) {
 		if(IsSubEntryPoint(i)) {

--- a/Core/Debugger/CodeDataLogger.cpp
+++ b/Core/Debugger/CodeDataLogger.cpp
@@ -18,7 +18,9 @@ CodeDataLogger::CodeDataLogger(Debugger* debugger, MemoryType memType, uint32_t 
 	_cdlData = new uint8_t[memSize];
 	Reset();
 
-	debugger->GetCdlManager()->RegisterCdl(memType, this);
+	if(debugger && debugger->GetCdlManager()) {
+		debugger->GetCdlManager()->RegisterCdl(memType, this);
+	}
 }
 
 CodeDataLogger::~CodeDataLogger()

--- a/Core/Debugger/CodeDataLogger.h
+++ b/Core/Debugger/CodeDataLogger.h
@@ -8,13 +8,15 @@ class Debugger;
 class CodeDataLogger
 {
 protected:
-	constexpr static int HeaderSize = 9; //"CDLv2" + 4-byte CRC32 value
+	static constexpr std::string_view CdlHeader = "CDLv2";
 
 	uint8_t* _cdlData = nullptr;
 	CpuType _cpuType = CpuType::Snes;
 	MemoryType _memType = {};
 	uint32_t _memSize = 0;
 	uint32_t _romCrc32 = 0;
+
+	constexpr static size_t HeaderSize = CdlHeader.length() + sizeof(CodeDataLogger::_romCrc32); //"CDLv2" + 4-byte CRC32 value
 	
 	virtual void InternalLoadCdlFile(uint8_t* cdlData, uint32_t cdlSize) {}
 	virtual void InternalSaveCdlFile(ofstream& cdlFile) {}

--- a/Mesen.sln
+++ b/Mesen.sln
@@ -41,6 +41,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SevenZip", "SevenZip\SevenZ
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Lua", "Lua\Lua.vcxproj", "{B609E0A0-5050-4871-91D6-E760633BCDD1}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Core.Test", "Core.Test\Core.Test.vcxproj", "{20DC996B-90E6-C763-B1CE-B6A48C8391F9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{78FEF1A1-6DF1-4CBB-A373-AE6FA7CE5CE0} = {78FEF1A1-6DF1-4CBB-A373-AE6FA7CE5CE0}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -150,6 +155,22 @@ Global
 		{B609E0A0-5050-4871-91D6-E760633BCDD1}.Release|Any CPU.ActiveCfg = Release|x64
 		{B609E0A0-5050-4871-91D6-E760633BCDD1}.Release|x64.ActiveCfg = Release|x64
 		{B609E0A0-5050-4871-91D6-E760633BCDD1}.Release|x64.Build.0 = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Debug|Any CPU.Build.0 = Debug|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Debug|x64.ActiveCfg = Debug|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Debug|x64.Build.0 = Debug|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Optimize|Any CPU.ActiveCfg = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Optimize|Any CPU.Build.0 = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Optimize|x64.ActiveCfg = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Optimize|x64.Build.0 = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Profile|Any CPU.ActiveCfg = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Profile|Any CPU.Build.0 = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Profile|x64.ActiveCfg = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.PGO Profile|x64.Build.0 = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Release|Any CPU.ActiveCfg = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Release|Any CPU.Build.0 = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Release|x64.ActiveCfg = Release|x64
+		{20DC996B-90E6-C763-B1CE-B6A48C8391F9}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Utilities/PlatformUtilities.h
+++ b/Utilities/PlatformUtilities.h
@@ -1,6 +1,10 @@
 #pragma once
 #include "pch.h"
 
+#ifdef _WIN32
+#pragma comment(lib, "winmm.lib")
+#endif
+
 class PlatformUtilities
 {
 public:


### PR DESCRIPTION
Hello, thank you very much for creating and sharing Mesen. It is excellent.

Would it be helpful if I offer to add some tests to the Mesen codebase? Would that make refactoring or bugfixing any easier, if we can have some confidence about parts of the codebase not breaking?

As a proof of concept I created some simple tests for the `CodeDataLogger` class.

Overall the `CodeDataLogger` works well. The tests I wrote confirm that it has correct behaviour and always does the right thing.
I created an integration test that creates a new `CodeDataLogger`, marks some bytes and code and data, saves the file to disk, and then reads and loads the file. It is able to confim the data is what we expect.

I was able to also create a few tests that cause `CodeDataLogger` to crash or die in unlikely scenarios - basically by passing in `nullptr` or invalid lengths and offsets that cause it to read outside of normal memory bounds.
These are unlikely scenarios. But I added a few bounds checks and null checks just to make the class more robust.


The most difficult part of creating the tests was not anything about writing the tests themselves - it was getting the new project set up and configured correctly in Visual Studio. So I thought that sharing a new test project with any small number of tests added might create a useful starting point. Anyone can then add more tests more easily for any part of the code that they want.

Thank you for your time.

**Before:**

<img width="1094" height="734" alt="mesen_cdl_tests_before_several_failing" src="https://github.com/user-attachments/assets/e31d12d1-e7f1-423c-bf6f-b6885cb7f1ff" />

**After:**

<img width="690" height="927" alt="mesen_cdl_tests_after_all_pass" src="https://github.com/user-attachments/assets/d1d9a97e-9235-4a3f-bde3-011ce6f17034" />
