### PR TITLE
1. Fix linux + mac builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build Mesen
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,21 @@ jobs:
 
       - name: Zip Mesen.app
         run: |
-          ditto -c -k --sequesterRsrc --keepParent bin/osx-${{ matrix.platform.arch }}/Release/osx-${{ matrix.platform.arch }}/publish/Mesen.app bin/osx-${{ matrix.platform.arch }}/Release/Mesen.app.zip
+          # Find the Mesen.app folder regardless of exactly which subfolder it landed in
+          APP_PATH=$(find bin/osx-${{ matrix.platform.arch }} -name "Mesen.app" -type d | head -n 1)
+
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::Could not find Mesen.app in bin directory!"
+            exit 1
+          fi
+
+          echo "Found app at: $APP_PATH"
+
+          # Create the destination directory if it doesn't exist
+          mkdir -p bin/osx-${{ matrix.platform.arch }}/Release/
+
+          # Zip it up
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" bin/osx-${{ matrix.platform.arch }}/Release/Mesen.app.zip
 
       - name: Upload Mesen
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,7 @@ jobs:
           ${{ matrix.make_flags }} make -j$(sysctl -n hw.logicalcpu)
 
       - name: Sign binary
+        if: github.event_name != 'pull_request' && env.CERT_DATA != ''
         env:
           APP_NAME: bin/osx-${{ matrix.platform.arch }}/Release/osx-${{ matrix.platform.arch }}/publish/Mesen.app
           CERT_DATA: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Zip Mesen.app
         run: |
           # Find the Mesen.app folder regardless of exactly which subfolder it landed in
-          APP_PATH=$(find bin/osx-${{ matrix.platform.arch }} -name "Mesen.app" -type d | head -n 1)
+          APP_PATH=$(find bin -name "Mesen.app" -type d | head -n 1)
 
           if [ -z "$APP_PATH" ]; then
             echo "::error::Could not find Mesen.app in bin directory!"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
       # Verify the Makefile correctly detects this specific Linux environment
       - name: Verify Environment
-        run: make verify-env ${{ matrix.make_flags }}
+        run: make verify-env ${{ matrix.make_flags }} REQ_PLAT=linux-${{ matrix.platform.path }} ARCH=${{ matrix.platform.path }}
         
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.
@@ -208,7 +208,7 @@ jobs:
 
       # Verify the Makefile correctly detects this specific macOS environment
       - name: Verify Environment
-        run: make verify-env ${{ matrix.make_flags }}
+        run: make verify-env ${{ matrix.make_flags }} REQ_PLAT=osx-${{ matrix.platform.arch }} ARCH=${{ matrix.platform.arch }}
 
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,5 +263,5 @@ jobs:
       - name: Upload Mesen
         uses: actions/upload-artifact@v4
         with:
-          name: Mesen (macOS - ${{ matrix.platform.os }} - ${{ matrix.compiler }})
+          name: Mesen (macOS - ${{ matrix.platform.os }} - ${{ matrix.platform.arch }} - ${{ matrix.compiler }})
           path: bin/osx-${{ matrix.platform.arch }}/Release/Mesen.app.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,10 @@ jobs:
             make_flags: "USE_AOT=true"
       fail-fast: false
     runs-on: ${{ matrix.platform.os }}
+    env:
+      # try to save time by preventing brew updates
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qy
-          sudo apt-get install -qy libsdl2-dev ccache # The compilers are already installed on GitHub's runners.
+          sudo apt-get install -qy libsdl2-dev ccache zip # The compilers are already installed on GitHub's runners.
 
       - name: Setup CCache
         uses: ./.github/actions/setup-ccache-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
       matrix:
         compiler: [clang, clang_aot]
         platform: [
-          {os: macos-13, arch: x64},
+          {os: macos-14, arch: x64},
           {os: macos-14, arch: arm64}
         ]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,10 @@ jobs:
        
       - name: Write commit SHA1 to file
         uses: ./.github/actions/build-sha1-action
+
+      # Verify the Makefile correctly detects this specific Linux environment
+      - name: Verify Environment
+        run: make verify-env ${{ matrix.make_flags }}
         
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.
@@ -201,6 +205,10 @@ jobs:
 
       - name: Write commit SHA1 to file
         uses: ./.github/actions/build-sha1-action
+
+      # Verify the Makefile correctly detects this specific macOS environment
+      - name: Verify Environment
+        run: make verify-env ${{ matrix.make_flags }}
 
       # stderr is not detected as a TTY, so diagnostics are by default printed without colours;
       # forcing colours makes the log a little nicer to read.

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -653,12 +653,13 @@
     <Exec Command="cd $(OutDir)&#xD;&#xA;rd Dependencies /s /q&#xD;&#xA;md Dependencies&#xD;&#xA;xcopy /s $(ProjectDir)Dependencies\* Dependencies&#xD;&#xA;copy libHarfBuzzSharp.dll Dependencies&#xD;&#xA;copy libSkiaSharp.dll Dependencies&#xD;&#xA;copy MesenCore.dll Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;del ..\Dependencies.zip&#xD;&#xA;powershell Compress-Archive -Path * -DestinationPath '..\Dependencies.zip' -Force&#xD;&#xA;copy ..\Dependencies.zip $(ProjectDir)" />
   </Target>
 
-	<Target Name="PreBuildLinux" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='linux-x64' Or '$(RuntimeIdentifier)'=='linux-arm64'">
-    <Exec Command="cd $(OutDir)&#xD;&#xA;rm -rf Dependencies&#xD;&#xA;mkdir Dependencies&#xD;&#xA;cp -R $(ProjectDir)/Dependencies/* Dependencies&#xD;&#xA;cp libHarfBuzzSharp.so Dependencies&#xD;&#xA;cp libSkiaSharp.so Dependencies&#xD;&#xA;cp MesenCore.so Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;rm ../Dependencies.zip&#xD;&#xA;zip -r ../Dependencies.zip *&#xD;&#xA;cp ../Dependencies.zip $(ProjectDir)" />
+  <Target Name="PreBuildLinux" BeforeTargets="PreBuildEvent" Condition="$(RuntimeIdentifier.StartsWith('linux-'))">
+    <Exec Command="/bin/bash ./prebuild_linux_mac.sh linux '../bin/$(RuntimeIdentifier)/$(Configuration)/' '$(ProjectDir)'" WorkingDirectory="$(ProjectDir)" />
   </Target>
-  
-	<Target Name="PreBuildOsx" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'">
-    <Exec Command="cp ./Assets/MesenIcon.icns $(OutDir)&#xD;&#xA;cd $(OutDir)&#xD;&#xA;rm -R Dependencies&#xD;&#xA;mkdir Dependencies&#xD;&#xA;cp -R $(ProjectDir)/Dependencies/* Dependencies&#xD;&#xA;cp libHarfBuzzSharp.dylib Dependencies&#xD;&#xA;cp libSkiaSharp.dylib Dependencies&#xD;&#xA;cp MesenCore.dylib Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;rm ../Dependencies.zip&#xD;&#xA;zip -r ../Dependencies.zip *&#xD;&#xA;cp ../Dependencies.zip $(ProjectDir)" />
+
+  <Target Name="PreBuildOsx" BeforeTargets="PreBuildEvent" Condition="$(RuntimeIdentifier.StartsWith('osx-'))">
+    <Exec Command="cp &quot;$(ProjectDir)Assets/MesenIcon.icns&quot; &quot;$(OutDir)&quot;" />
+    <Exec Command="/bin/bash ./prebuild_linux_mac.sh osx '../bin/$(RuntimeIdentifier)/$(Configuration)/' '$(ProjectDir)'" WorkingDirectory="$(ProjectDir)" />
   </Target>
 
 </Project>

--- a/UI/prebuild_linux_mac.sh
+++ b/UI/prebuild_linux_mac.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # Exit immediately if a command fails
+
+PLATFORM=$1 # 'linux' or 'osx'
+OUTDIR="${2%/}" # remove trailing slash if present
+PROJECTDIR="${3%/}"
+EXT="so"
+if [ "$PLATFORM" == "osx" ]; then EXT="dylib"; fi
+
+echo "Packaging dependencies for $PLATFORM..."
+
+mkdir -p "$OUTDIR"
+cd "$OUTDIR"
+rm -rf Dependencies
+mkdir -p Dependencies
+
+# 1. Copy static assets
+if [ -d "$PROJECTDIR/Dependencies" ]; then
+    cp -R "$PROJECTDIR/Dependencies/." Dependencies/
+fi
+
+# 2. Copy native libs (with a fallback check)
+# NuGet puts these in runtimes/[rid]/native/ - we look there if not in root
+LIBS=("libHarfBuzzSharp.$EXT" "libSkiaSharp.$EXT" "MesenCore.$EXT")
+
+for LIB in "${LIBS[@]}"; do
+    FOUND_LIB=$(find . -name "$LIB" -print -quit)
+    if [ -n "$FOUND_LIB" ]; then
+        cp "$FOUND_LIB" Dependencies/
+    fi
+done
+
+# 3. Zip it up
+cd Dependencies
+rm -f ../Dependencies.zip
+zip -r ../Dependencies.zip .
+
+mv ../Dependencies.zip "$PROJECTDIR/"

--- a/makefile
+++ b/makefile
@@ -131,7 +131,7 @@ endif
 ifeq ($(USE_AOT),true)
 	PUBLISHFLAGS ?=  -r $(MESENPLATFORM) -p:PublishSingleFile=false -p:PublishAot=true -p:SelfContained=true
 else
-	PUBLISHFLAGS ?=  -r $(MESENPLATFORM) --no-self-contained true -p:PublishSingleFile=true
+	PUBLISHFLAGS ?=  -r $(MESENPLATFORM) --no-self-contained -p:PublishSingleFile=true
 endif
 
 

--- a/makefile
+++ b/makefile
@@ -272,13 +272,23 @@ verify-all-env:
 	@echo "----------------------------------------------------------------------------------------------------------"
 	@printf $(PRINT_FORMAT) "INPUT" "EXPECTED (PLAT/FLAGS)" "" "ACTUAL (PLAT/FLAGS)" "" "RESULT"
 	@echo "----------------------------------------------------------------------------------------------------------"
+	@# --- TEST GROUP 1: Auto-Detection (No ARCH param) ---
+	@# These prove the Makefile works out-of-the-box on different hardware
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-x64   E_FLAGS="-m64" || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=aarch64    E_PLAT=linux-arm64 E_FLAGS=""      USE_GCC=true || touch .test_failed
-	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=x86_64     E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-arm64   E_FLAGS="-m64" || touch .test_failed
-	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=aarch64    E_PLAT=osx-arm64   E_FLAGS="-m64" || touch .test_failed
-	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
+
+	@# --- TEST GROUP 2: Explicit Overrides (With ARCH param) ---
+	@# These prove the Makefile correctly ignores the hardware when told to
+	@# Case: On x86_64 hardware, but ARCH says arm64
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64 ARCH=arm64 E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
+
+	@# Case: On ARM64 hardware, but ARCH says x64
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64  ARCH=x64   E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
+
+	@# Case: Using alternate naming (aarch64) in the ARCH param
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64 ARCH=aarch64 E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
 	@echo "----------------------------------------------------------------------------------------------------------"
 	@if [ -f .test_failed ]; then \
 		rm .test_failed; \

--- a/makefile
+++ b/makefile
@@ -25,7 +25,10 @@ LINKCHECKUNRESOLVED := -Wl,-z,defs
 
 LINKOPTIONS :=
 MESENOS :=
-UNAME_S := $(shell uname -s)
+
+# Use ?= so we can override these during testing
+UNAME_S ?= $(shell uname -s)
+MACHINE ?= $(shell uname -m)
 
 ifeq ($(UNAME_S),Linux)
 	MESENOS := linux
@@ -42,14 +45,12 @@ endif
 
 MESENFLAGS += -m64
 
-MACHINE := $(shell uname -m)
 ifeq ($(MACHINE),x86_64)
 	MESENPLATFORM := $(MESENOS)-x64
 endif
 ifneq ($(filter %86,$(MACHINE)),)
 	MESENPLATFORM := $(MESENOS)-x64
 endif
-# TODO: this returns `aarch64` on one of my machines...
 ifneq ($(filter arm%,$(MACHINE)),)
 	MESENPLATFORM := $(MESENOS)-arm64
 endif
@@ -57,7 +58,7 @@ ifeq ($(MACHINE),aarch64)
 	MESENPLATFORM := $(MESENOS)-arm64
 	ifeq ($(USE_GCC),true)
 		#don't set -m64 on arm64 for gcc (unrecognized option)
-		MESENFLAGS=
+		MESENFLAGS := $(filter-out -m64,$(MESENFLAGS))
 	endif
 endif
 
@@ -248,20 +249,22 @@ clean:
 
 .PHONY: test-all-configs test-env
 test-all-configs:
-	@echo "Checking Makefile architecture detection logic..."
-	@echo "------------------------------------------------"
-	@$(MAKE) --no-print-directory test-env UNAME_S=Linux MACHINE=x86_64
-	@$(MAKE) --no-print-directory test-env UNAME_S=Linux MACHINE=aarch64
-	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=x86_64
-	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=arm64
-	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=aarch64
-	@echo "------------------------------------------------"
-	@echo "Verification Complete."
+	@echo "Validating makefile architecture detection:"
+	@echo "----------------------------------------------------------------------------------------------------------"
+	@printf "%-15s | %-25s | %-25s | %-10s\n" "INPUT" "EXPECTED (PLAT/FLAGS)" "ACTUAL (PLAT/FLAGS)" "RESULT"
+	@echo "----------------------------------------------------------------------------------------------------------"
+	@$(MAKE) --no-print-directory test-env UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-x64   E_FLAGS="-m64"
+	@$(MAKE) --no-print-directory test-env UNAME_S=Linux  MACHINE=aarch64    E_PLAT=linux-arm64 E_FLAGS=""      USE_GCC=true
+	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=x86_64     E_PLAT=osx-x64     E_FLAGS="-m64"
+	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-arm64   E_FLAGS="-m64"
+	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=aarch64    E_PLAT=osx-arm64   E_FLAGS="-m64"
+	@echo "----------------------------------------------------------------------------------------------------------"
 
-# We define the logic again here for the test because top-level variables are already evaluated.
 test-env:
-	$(eval TEST_OS := $(if $(filter Darwin,$(UNAME_S)),osx,linux))
-	$(eval TEST_PLAT := $(if $(filter x86_64 %86,$(MACHINE)),$(TEST_OS)-x64,$(TEST_OS)-arm64))
-	$(eval TEST_FLAGS := $(if $(filter Darwin,$(UNAME_S)),-m64,$(if $(filter aarch64,$(MACHINE)),,-m64)))
-	@printf "Input: %-15s | Expected Platform: %-12s | Expected Arch Flag: %s\n" \
-		"$(UNAME_S)-$(MACHINE)" "$(TEST_PLAT)" "$(filter -m64,$(TEST_FLAGS))"
+	$(eval ACTUAL_FLAGS := $(filter -m64,$(MESENFLAGS)))
+	$(eval PASS := $(shell [ "$(MESENPLATFORM)" = "$(E_PLAT)" ] && [ "$(ACTUAL_FLAGS)" = "$(E_FLAGS)" ] && echo "PASS" || echo "FAIL"))
+	@printf "%-15s | %-13s %-11s | %-13s %-11s | %-10s\n" \
+		"$(UNAME_S)-$(MACHINE)" \
+		"$(E_PLAT)" "$(E_FLAGS)" \
+		"$(MESENPLATFORM)" "$(ACTUAL_FLAGS)" \
+		"$(PASS)"

--- a/makefile
+++ b/makefile
@@ -244,3 +244,24 @@ clean:
 	rm -r -f $(LUAOBJ)
 	rm -r -f $(MACOSOBJ)
 	rm -r -f $(DLLOBJ)
+
+
+.PHONY: test-all-configs test-env
+test-all-configs:
+	@echo "Checking Makefile architecture detection logic..."
+	@echo "------------------------------------------------"
+	@$(MAKE) --no-print-directory test-env UNAME_S=Linux MACHINE=x86_64
+	@$(MAKE) --no-print-directory test-env UNAME_S=Linux MACHINE=aarch64
+	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=x86_64
+	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=arm64
+	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=aarch64
+	@echo "------------------------------------------------"
+	@echo "Verification Complete."
+
+# We define the logic again here for the test because top-level variables are already evaluated.
+test-env:
+	$(eval TEST_OS := $(if $(filter Darwin,$(UNAME_S)),osx,linux))
+	$(eval TEST_PLAT := $(if $(filter x86_64 %86,$(MACHINE)),$(TEST_OS)-x64,$(TEST_OS)-arm64))
+	$(eval TEST_FLAGS := $(if $(filter Darwin,$(UNAME_S)),-m64,$(if $(filter aarch64,$(MACHINE)),,-m64)))
+	@printf "Input: %-15s | Expected Platform: %-12s | Expected Arch Flag: %s\n" \
+		"$(UNAME_S)-$(MACHINE)" "$(TEST_PLAT)" "$(filter -m64,$(TEST_FLAGS))"

--- a/makefile
+++ b/makefile
@@ -273,9 +273,11 @@ verify-all-env:
 	@echo "----------------------------------------------------------------------------------------------------------"
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-x64   E_FLAGS="-m64" || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=aarch64    E_PLAT=linux-arm64 E_FLAGS=""      USE_GCC=true || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=x86_64     E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-arm64   E_FLAGS="-m64" || touch .test_failed
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=aarch64    E_PLAT=osx-arm64   E_FLAGS="-m64" || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
 	@echo "----------------------------------------------------------------------------------------------------------"
 	@if [ -f .test_failed ]; then \
 		rm .test_failed; \

--- a/makefile
+++ b/makefile
@@ -31,9 +31,10 @@ UNAME_S ?= $(shell uname -s)
 MACHINE ?= $(shell uname -m)
 
 ifneq ($(ARCH),)
-	ifeq ($(filter x64 x86_64,$(ARCH)),$(ARCH))
+	ifneq (,$(findstring x64,$(ARCH))$(findstring x86_64,$(ARCH)))
 		override MACHINE := x86_64
-	else ifeq ($(filter arm64 aarch64,$(ARCH)),$(ARCH))
+	endif
+	ifneq (,$(findstring arm64,$(ARCH))$(findstring aarch64,$(ARCH)))
 		override MACHINE := aarch64
 	endif
 endif

--- a/makefile
+++ b/makefile
@@ -290,13 +290,13 @@ verify-all-env:
 	@# --- TEST GROUP 2: Explicit Overrides (With ARCH param) ---
 	@# These prove the Makefile correctly ignores the hardware when told to
 	@# Case: On x86_64 hardware, but ARCH says arm64
-	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64 ARCH=arm64 E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-arm64 E_FLAGS=""     ARCH=arm64 USE_GCC=true || touch .test_failed
 
 	@# Case: On ARM64 hardware, but ARCH says x64
-	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64  ARCH=x64   E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-x64     E_FLAGS="-m64" ARCH=x64 || touch .test_failed
 
 	@# Case: Using alternate naming (aarch64) in the ARCH param
-	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64 ARCH=aarch64 E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-arm64 E_FLAGS=""     ARCH=aarch64 USE_GCC=true || touch .test_failed
 	@echo "----------------------------------------------------------------------------------------------------------"
 	@if [ -f .test_failed ]; then \
 		rm .test_failed; \

--- a/makefile
+++ b/makefile
@@ -260,9 +260,10 @@ PRINT_FORMAT := "%-15s | %-13s %-11s | %-13s %-11s | %-10s\n"
 # Target for CI: verify the current machine's environment
 verify-env:
 	@echo "Checking Build Environment..."
-	@printf $(PRINT_FORMAT) "INPUT" "EXPECTED" "" "ACTUAL" "" "RESULT"
+	@printf $(PRINT_FORMAT) "INPUT" "MATRIX_REQ" "" "ACTUAL" "" "RESULT"
+	# compare what the matrix requested (REQ_PLAT) vs what the Makefile found (MESENPLATFORM)
 	@$(MAKE) --no-print-directory test-env-row \
-		E_PLAT="$(MESENPLATFORM)" \
+		E_PLAT="$(if $(REQ_PLAT),$(REQ_PLAT),$(MESENPLATFORM))" \
 		E_FLAGS="$(filter -m64,$(MESENFLAGS))"
 
 verify-all-env:

--- a/makefile
+++ b/makefile
@@ -30,6 +30,14 @@ MESENOS :=
 UNAME_S ?= $(shell uname -s)
 MACHINE ?= $(shell uname -m)
 
+ifneq ($(ARCH),)
+	ifeq ($(filter x64 x86_64,$(ARCH)),$(ARCH))
+		override MACHINE := x86_64
+	else ifeq ($(filter arm64 aarch64,$(ARCH)),$(ARCH))
+		override MACHINE := aarch64
+	endif
+endif
+
 ifeq ($(UNAME_S),Linux)
 	MESENOS := linux
 	SHAREDLIB := MesenCore.so

--- a/makefile
+++ b/makefile
@@ -202,6 +202,7 @@ ui: InteropDLL/$(OBJFOLDER)/$(SHAREDLIB)
 	mkdir -p $(OUTFOLDER)/Dependencies
 	rm -fr $(OUTFOLDER)/Dependencies/*
 	cp InteropDLL/$(OBJFOLDER)/$(SHAREDLIB) $(OUTFOLDER)/$(SHAREDLIB)
+	chmod +x UI/prebuild_linux_mac.sh
 	#Called twice because the first call copies native libraries to the bin folder which need to be included in Dependencies.zip
 	#Don't run with AOT flags the first time to reduce build duration
 	dotnet publish UI/UI.csproj -c $(BUILD_TYPE) $(OPTIMIZEUI) -r $(MESENPLATFORM)

--- a/makefile
+++ b/makefile
@@ -247,24 +247,55 @@ clean:
 	rm -r -f $(DLLOBJ)
 
 
-.PHONY: test-all-configs test-env
-test-all-configs:
-	@echo "Validating makefile architecture detection:"
-	@echo "----------------------------------------------------------------------------------------------------------"
-	@printf "%-15s | %-25s | %-25s | %-10s\n" "INPUT" "EXPECTED (PLAT/FLAGS)" "ACTUAL (PLAT/FLAGS)" "RESULT"
-	@echo "----------------------------------------------------------------------------------------------------------"
-	@$(MAKE) --no-print-directory test-env UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-x64   E_FLAGS="-m64"
-	@$(MAKE) --no-print-directory test-env UNAME_S=Linux  MACHINE=aarch64    E_PLAT=linux-arm64 E_FLAGS=""      USE_GCC=true
-	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=x86_64     E_PLAT=osx-x64     E_FLAGS="-m64"
-	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-arm64   E_FLAGS="-m64"
-	@$(MAKE) --no-print-directory test-env UNAME_S=Darwin MACHINE=aarch64    E_PLAT=osx-arm64   E_FLAGS="-m64"
-	@echo "----------------------------------------------------------------------------------------------------------"
+# --- Environment Reporting & Validation ---
 
-test-env:
-	$(eval ACTUAL_FLAGS := $(filter -m64,$(MESENFLAGS)))
-	$(eval PASS := $(shell [ "$(MESENPLATFORM)" = "$(E_PLAT)" ] && [ "$(ACTUAL_FLAGS)" = "$(E_FLAGS)" ] && echo "PASS" || echo "FAIL"))
-	@printf "%-15s | %-13s %-11s | %-13s %-11s | %-10s\n" \
+# Shared format for the table rows
+PRINT_FORMAT := "%-15s | %-13s %-11s | %-13s %-11s | %-10s\n"
+
+.PHONY: verify-env verify-all-env test-env-row
+
+# Hide the "make[1]: Entering directory..." noise
+.SILENT: test-env-row
+
+# Target for CI: verify the current machine's environment
+verify-env:
+	@echo "Checking Build Environment..."
+	@printf $(PRINT_FORMAT) "INPUT" "EXPECTED" "" "ACTUAL" "" "RESULT"
+	@$(MAKE) --no-print-directory test-env-row \
+		E_PLAT="$(MESENPLATFORM)" \
+		E_FLAGS="$(filter -m64,$(MESENFLAGS))"
+
+verify-all-env:
+	@rm -f .test_failed
+	@echo "Validating Makefile Architecture Detection Logic:"
+	@echo "----------------------------------------------------------------------------------------------------------"
+	@printf $(PRINT_FORMAT) "INPUT" "EXPECTED (PLAT/FLAGS)" "" "ACTUAL (PLAT/FLAGS)" "" "RESULT"
+	@echo "----------------------------------------------------------------------------------------------------------"
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-x64   E_FLAGS="-m64" || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=aarch64    E_PLAT=linux-arm64 E_FLAGS=""      USE_GCC=true || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=x86_64     E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64      E_PLAT=osx-arm64   E_FLAGS="-m64" || touch .test_failed
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=aarch64    E_PLAT=osx-arm64   E_FLAGS="-m64" || touch .test_failed
+	@echo "----------------------------------------------------------------------------------------------------------"
+	@if [ -f .test_failed ]; then \
+		rm .test_failed; \
+		echo "Verification FAILED!"; \
+		exit 1; \
+	else \
+		echo "Verification Complete. All tests PASSED."; \
+	fi
+
+test-env-row:
+	$(eval ACTUAL_FLAGS := $(strip $(filter -m64,$(MESENFLAGS))))
+	$(eval EXP_FLAGS := $(strip $(E_FLAGS)))
+	$(eval PLAT_MATCH := $(if $(filter $(E_PLAT),$(MESENPLATFORM)),OK,FAIL))
+	$(eval FLAG_MATCH := $(if $(subst $(EXP_FLAGS),,$(ACTUAL_FLAGS))$(subst $(ACTUAL_FLAGS),,$(EXP_FLAGS)),FAIL,OK))
+	$(eval PASS := $(if $(filter OKOK,$(PLAT_MATCH)$(FLAG_MATCH)),PASS,FAIL))
+	@printf $(PRINT_FORMAT) \
 		"$(UNAME_S)-$(MACHINE)" \
-		"$(E_PLAT)" "$(E_FLAGS)" \
+		"$(E_PLAT)" "$(EXP_FLAGS)" \
 		"$(MESENPLATFORM)" "$(ACTUAL_FLAGS)" \
 		"$(PASS)"
+	@# Return a non-zero exit code ONLY so verify-all-env can catch it with ||
+	@if [ "$(PASS)" = "FAIL" ]; then exit 1; fi
+

--- a/makefile
+++ b/makefile
@@ -204,8 +204,8 @@ ui: InteropDLL/$(OBJFOLDER)/$(SHAREDLIB)
 	cp InteropDLL/$(OBJFOLDER)/$(SHAREDLIB) $(OUTFOLDER)/$(SHAREDLIB)
 	#Called twice because the first call copies native libraries to the bin folder which need to be included in Dependencies.zip
 	#Don't run with AOT flags the first time to reduce build duration
-	cd UI && dotnet publish -c $(BUILD_TYPE) $(OPTIMIZEUI) -r $(MESENPLATFORM)
-	cd UI && dotnet publish -c $(BUILD_TYPE) $(OPTIMIZEUI) $(PUBLISHFLAGS)
+	dotnet publish UI/UI.csproj -c $(BUILD_TYPE) $(OPTIMIZEUI) -r $(MESENPLATFORM)
+	dotnet publish UI/UI.csproj -c $(BUILD_TYPE) $(OPTIMIZEUI) $(PUBLISHFLAGS)
 
 core: InteropDLL/$(OBJFOLDER)/$(SHAREDLIB)
 

--- a/makefile
+++ b/makefile
@@ -297,6 +297,13 @@ verify-all-env:
 
 	@# Case: Using alternate naming (aarch64) in the ARCH param
 	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64     E_PLAT=linux-arm64 E_FLAGS=""     ARCH=aarch64 USE_GCC=true || touch .test_failed
+
+	@# --- TEST GROUP 3: Resilient Naming (Fuzzy ARCH matching) ---
+	@# Test: ARCH contains the full platform name (common in CI)
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Darwin MACHINE=arm64  ARCH=osx-x64   E_PLAT=osx-x64     E_FLAGS="-m64" || touch .test_failed
+
+	@# Test: ARCH contains extra spaces or different casing (handled by findstring)
+	@$(MAKE) --no-print-directory test-env-row UNAME_S=Linux  MACHINE=x86_64 ARCH=linux-arm64 E_PLAT=linux-arm64 E_FLAGS="" USE_GCC=true || touch .test_failed
 	@echo "----------------------------------------------------------------------------------------------------------"
 	@if [ -f .test_failed ]; then \
 		rm .test_failed; \


### PR DESCRIPTION
Hello, it appears that on the lastest `master` branch commit, fabc9a6 , some of the current mac and linux builds are broken in GitHub cloud builders.
But with just a few small edits - it is easy to fix them and make them pass again.

I [created a test PR in my own fork of the repo](https://github.com/culix-7/Mesen2/pull/2) so I could run the GitHub runners and fix.
You can see here that several of the builds fail - https://github.com/culix-7/Mesen2/actions/runs/20806315078

I have made several edits in this PR to fix the build. You can see with this that all of the builds now pass! - https://github.com/culix-7/Mesen2/actions/runs/20941800372/

I realize that reading makefiles can be messy, and this might be a large number of changes. I have tried to clean up the commits to make them clear and easy to follow.

Essentially:

1. **Move the linux and mac prebuild steps** for the `UI` project out of the Visual Studio project file and **into a `UI/prebuild_linux_mac.sh` file**. Hopefully this makes it easier to view and edit for the future.
1. Fix a few path calculations in the prebuild step
1. Add some install dependencies that were missing
1. **Update the mac OS 13 runner to mac OS 14.** 13 has been officially turned off by GitHub as of December 2025 - https://github.com/actions/runner-images/issues/13046
1. **Add some new targets in the makefile to run tests.**
    * `verify-all-env:` checks all of the `UNAME_S`, `MACHINE`, and platform/os flags that we use during building.
    * Anyone can call `make verify-all-env` on the command line to test this and verify that the makefile logic does the right thing.
    * Hopefully this makes it a bit easier to edit and test the makefile in the future
1. **Add a new `verify-env` target to test just one platform.**
    * I added this as a 'sanity check' step to the mac and linux builds, to make sure we can find the right paths etc. before we spend time building
1. After all that - cleaned up some of the makefile logic so it calculates the right architecture and uses all of the right paths during building

With that - everything passes! :D


You can see a passing run here - https://github.com/culix-7/Mesen2/actions/runs/20941800372/

I hope that helps.

..

**Before:**

<img width="316" height="770" alt="mesen_build_steps_before" src="https://github.com/user-attachments/assets/58ba313e-bf30-4c72-9ef9-02870c2821d5" />



**After:**

<img width="314" height="768" alt="mesen_build_steps_after" src="https://github.com/user-attachments/assets/4504a766-9b9e-4ac0-82a4-61ba6f94663b" />
