### PR TITLE
NES: Fixed GetInternalOpenBus returning external bus value by mistake.

### DIFF
--- a/Core/NES/OpenBusHandler.h
+++ b/Core/NES/OpenBusHandler.h
@@ -31,7 +31,7 @@ public:
 
 	__forceinline uint8_t GetInternalOpenBus()
 	{
-		return _externalOpenBus;
+		return _internalOpenBus;
 	}
 
 	__forceinline void SetOpenBus(uint8_t value, bool setInternalOnly)


### PR DESCRIPTION
#### Summary

Fix `OpenBusHandler::GetInternalOpenBus()` returning external bus value

#### Description

Fixed a bug in `OpenBusHandler` where `GetInternalOpenBus()` incorrectly returned `_externalOpenBus` instead of `_internalOpenBus`.

#### Technical Details

- **Root Cause**: The method returned `_externalOpenBus` when it should return `_internalOpenBus`.
- **Impact**: While ` $ 4015` reads may appear unaffected in simple cases (since `GetInternalOpenBus()` is called *before* updating the bus), the bug breaks correctness whenever the internal and external bus values differ — such as after a ` $ 4015` read or in advanced mappers/debuggers that rely on accurate internal bus state.
- **Hardware Behavior**: Reading ` $ 4015` does not drive the external bus; only the CPU's internal bus is updated. Thus, internal and external open bus values must be tracked separately.

> [APU#Status_($4015)](https://www.nesdev.org/wiki/APU#Status_($4015))
> **Note**: The ` $ 4015` bit 5 uses the internal open bus value **from before the read**, which is correctly captured in the current call order. The bug primarily affects other consumers of `GetInternalOpenBus()` or future code relying on bus state separation.
