### PR TITLE
Linux Compilation and AppImage Fixes

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -14,6 +14,9 @@ Once SDL2 and the .NET 8 SDK are installed, run `make` to compile with Clang.
 To compile with GCC instead, use `USE_GCC=true make`.  
 **Note:** Mesen usually runs faster when built with Clang instead of GCC.
 
+To create an AppImage, you must execute appimage.sh from the root folder, i.e., from the terminal:  Linux/appimage/appimage.sh
+
+Alternatively, navigate to ./Linux/appimage/ and execute appimage_reldir.sh, i.e., from the terminal:  ./appimage_reldir.sh
 
 ## macOS
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -10,13 +10,13 @@ To build under Linux you need a version of Clang or GCC that supports C++17.
 
 Additionally, SDL2 and the [.NET 8 SDK](https://learn.microsoft.com/en-us/dotnet/core/install/linux) must also be installed.
 
-Once SDL2 and the .NET 8 SDK are installed, run `make` to compile with Clang.  
+To create an AppImage, you must execute appimage.sh from the root folder of the project, i.e., from the terminal:  Linux/appimage/appimage.sh
+(The appimage.sh script will initiate the compilation process itself.)
+
+
+If not creating an AppImage, once SDL2 and the .NET 8 SDK are installed, run `make` to compile with Clang.  
 To compile with GCC instead, use `USE_GCC=true make`.  
 **Note:** Mesen usually runs faster when built with Clang instead of GCC.
-
-To create an AppImage, you must execute appimage.sh from the root folder, i.e., from the terminal:  Linux/appimage/appimage.sh
-
-Alternatively, navigate to ./Linux/appimage/ and execute appimage_reldir.sh, i.e., from the terminal:  ./appimage_reldir.sh
 
 ## macOS
 

--- a/Linux/appimage/appimage.sh
+++ b/Linux/appimage/appimage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PUBLISHFLAGS="-r linux-x64 --no-self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true"
+export PUBLISHFLAGS="-r linux-x64 --self-contained -p:PublishSingleFile=true -p:PublishReadyToRun=true"
 make -j$(nproc) -O LTO=true STATICLINK=true SYSTEM_LIBEVDEV=false
 
 curl -SL https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -o appimagetool

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ These builds require **.NET 8** to be installed (except the Windows 7 build whic
 For Linux and macOS, **SDL2** must also be installed.
 
 * [Windows 7 / 8 (.NET 6)](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net6.0%29.zip)  
-* [Linux x64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)  
+* [Linux x64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)  (see AppImage note below)
 * [Linux ARM64](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang%29.zip)  
-* [Linux ARM64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)
+* [Linux ARM64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)  (see AppImage note below)
 
 
 #### <ins>Notes</ins> ####
 
 Other builds are also available in the [Actions](https://github.com/SourMesen/Mesen2/actions) tab.
+
+For AppImage's, where you are utilizing XDG relative/local directories (<AppImage filename>.config and <AppImage filename>.home), on first launch, be sure to select "Store the data in my user profile" option for "Data Storage Location" so that the program does in fact utilize those directories.
 
 **SteamOS**: See [SteamOS.md](SteamOS.md)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The latest stable version is available from the [releases on GitHub](https://git
 
 [![Mesen](https://github.com/SourMesen/Mesen2/actions/workflows/build.yml/badge.svg)](https://github.com/SourMesen/Mesen2/actions/workflows/build.yml)
 
-#### <ins>Native builds</ins> (recommended) ####
+#### <ins>Native builds (AOT)</ins> (recommended) ####
 
 These builds don't require .NET to be installed.  
 

--- a/makefile
+++ b/makefile
@@ -131,7 +131,7 @@ endif
 ifeq ($(USE_AOT),true)
 	PUBLISHFLAGS ?=  -r $(MESENPLATFORM) -p:PublishSingleFile=false -p:PublishAot=true -p:SelfContained=true
 else
-	PUBLISHFLAGS ?=  -r $(MESENPLATFORM) --no-self-contained true -p:PublishSingleFile=true
+	PUBLISHFLAGS ?=  -r $(MESENPLATFORM) --no-self-contained -p:PublishSingleFile=true
 endif
 
 


### PR DESCRIPTION
Attempting to compile on Linux results in an error wherein the dotnet program attempts to load a phantom "true" project rather than the "UI.csproj" that it should, due to the use of a faulty CLI switch for the dotnet program. This was fixed.

Attempting to create an AppImage results in a similar error wherein the dotnet program attempts to load a phantom "false" project rather than the "UI.csproj" that it should, also due to the use of a faulty CLI switch for the dotnet program. This was also fixed.

Additionally, COMPILNG.md was updated with instructions to initiate appimage.sh from the project's root directory. Further, README.md was updated to clarify that Native builds utilize AOT compilation. Lastly, README.md was updated with instructions to select "Store the data in my user profile" option for "Data Storage Location" on first launch, if utilizing XDG local/relative directories with AppImage's.