### PR TITLE
Filter profiler data by function subtree

### DIFF
--- a/Core/Debugger/Profiler.cpp
+++ b/Core/Debugger/Profiler.cpp
@@ -21,10 +21,29 @@ Profiler::~Profiler()
 {
 }
 
+
+int32_t Profiler::CreateKey(AddressInfo &addr)
+{
+    return addr.Address | ((uint8_t)addr.Type << 24);
+}
+
+
+void Profiler::SetFilter(AddressInfo &addr)
+{
+    _filter = CreateKey(addr);
+}
+
+
+void Profiler::ClearFilter()
+{
+    _filter.reset();
+}
+
+
 void Profiler::StackFunction(AddressInfo &addr, StackFrameFlags stackFlag)
 {
 	if(addr.Address >= 0) {
-		uint32_t key = addr.Address | ((uint8_t)addr.Type << 24);
+		uint32_t key = CreateKey(addr);
 		if(_functions.find(key) == _functions.end()) {
 			_functions[key] = ProfiledFunction();
 			_functions[key].Address = addr;
@@ -56,14 +75,31 @@ void Profiler::StackFunction(AddressInfo &addr, StackFrameFlags stackFlag)
 void Profiler::UpdateCycles()
 {
 	uint64_t masterClock = _cpuDebugger->GetCpuCycleCount(true);
-	
+
+    int filterFunctionSlot = -1;
+    int stackDepthFilter = 0;
+    if (_filter) {
+        int32_t len = (int32_t)_functionStack.size();
+        for(int32_t i = len - 1; i >= 0; i--) {
+            if (_functionStack[i] == *_filter) {
+                filterFunctionSlot = i;
+                break;
+            }
+        }
+        if (filterFunctionSlot == -1) {
+            _prevMasterClock = masterClock;
+            return;
+        }
+        stackDepthFilter = filterFunctionSlot;
+    }
+
 	ProfiledFunction& func = _functions[_currentFunction];
 	uint64_t clockGap = masterClock - _prevMasterClock;
 	func.ExclusiveCycles += clockGap;
 	func.InclusiveCycles += clockGap;
-	
+
 	int32_t len = (int32_t)_functionStack.size();
-	for(int32_t i = len - 1; i >= 0; i--) {
+	for(int32_t i = len - 1; i >= stackDepthFilter; i--) {
 		_functions[_functionStack[i]].InclusiveCycles += clockGap;
 		if(_stackFlags[i] != StackFrameFlags::None) {
 			//Don't apply inclusive times to stack frames before an IRQ/NMI
@@ -114,7 +150,7 @@ void Profiler::ResetState()
 void Profiler::InternalReset()
 {
 	ResetState();
-	
+
 	_functions.clear();
 	_functions[ResetFunctionIndex] = ProfiledFunction();
 	_functions[ResetFunctionIndex].Address = { ResetFunctionIndex, MemoryType::None };
@@ -123,7 +159,7 @@ void Profiler::InternalReset()
 void Profiler::GetProfilerData(ProfiledFunction* profilerData, uint32_t& functionCount)
 {
 	DebugBreakHelper helper(_debugger);
-	
+
 	UpdateCycles();
 
 	functionCount = 0;

--- a/Core/Debugger/Profiler.h
+++ b/Core/Debugger/Profiler.h
@@ -32,12 +32,19 @@ private:
 	uint64_t _prevMasterClock = 0;
 	int32_t _currentFunction = -1;
 
+	std::optional<int32_t> _filter;
+
 	void InternalReset();
 	void UpdateCycles();
+
+	int32_t CreateKey(AddressInfo &addr);
 
 public:
 	Profiler(Debugger* debugger, IDebugger* cpuDebugger);
 	~Profiler();
+
+	void SetFilter(AddressInfo &parentFunction);
+	void ClearFilter();
 
 	void StackFunction(AddressInfo& addr, StackFrameFlags stackFlag);
 	void UnstackFunction();

--- a/InteropDLL/DebugApiWrapper.cpp
+++ b/InteropDLL/DebugApiWrapper.cpp
@@ -105,6 +105,16 @@ extern "C"
 		WithToolVoid(GetCallstackManager(cpuType), GetProfiler()->GetProfilerData(profilerData, functionCount));
 	}
 
+	DllExport void __stdcall SetProfilerFilter(CpuType cpuType, AddressInfo addr)
+	{
+		WithToolVoid(GetCallstackManager(cpuType), GetProfiler()->SetFilter(addr));
+	}
+
+	DllExport void __stdcall ClearProfilerFilter(CpuType cpuType)
+	{
+		WithToolVoid(GetCallstackManager(cpuType), GetProfiler()->ClearFilter());
+	}
+
 	DllExport void __stdcall ResetProfiler(CpuType cpuType) { WithToolVoid(GetCallstackManager(cpuType), GetProfiler()->Reset()); }
 
 	DllExport void __stdcall GetConsoleState(BaseState& state, ConsoleType consoleType) { WithDebugger(void, GetConsoleState(state, consoleType)); }

--- a/UI/Debugger/Utilities/ContextMenuAction.cs
+++ b/UI/Debugger/Utilities/ContextMenuAction.cs
@@ -882,6 +882,10 @@ namespace Mesen.Debugger.Utilities
 		[IconFile("NextArrow")]
 		NavigateForward,
 
+		[IconFile("Find")]
+		SetProfilerFilter,
+		[IconFile("Close")]
+		ClearProfilerFilter,
 		[IconFile("Close")]
 		ResetProfilerData,
 		[IconFile("Copy")]

--- a/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
@@ -59,6 +59,7 @@ namespace Mesen.Debugger.ViewModels
 				},
 				new ContextMenuAction() {
 					ActionType = ActionType.SetProfilerFilter,
+					IsEnabled = () => SelectedTab?.Selection.SelectedItem != null,
 					OnClick = () => {
 						var item = SelectedTab?.Selection.SelectedItem;
 						if(item != null && SelectedTab != null)

--- a/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
@@ -57,6 +57,19 @@ namespace Mesen.Debugger.ViewModels
 					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.Copy),
 					OnClick = () => wnd?.GetVisualDescendants().Where(a => a is DataBox).Cast<DataBox>().FirstOrDefault()?.CopyToClipboard()
 				},
+				new ContextMenuAction() {
+					ActionType = ActionType.SetProfilerFilter,
+					OnClick = () => {
+						var item = SelectedTab?.Selection.SelectedItem;
+						if(item != null && SelectedTab != null)
+							SelectedTab.SetFilter(item.FuncData, SelectedTab.CpuType);
+					}
+				},
+				new ContextMenuAction() {
+					ActionType = ActionType.ClearProfilerFilter,
+					IsEnabled = () => SelectedTab?.HasFilter ?? false,
+					OnClick = () => SelectedTab?.ClearFilter()
+				},
 				new ContextMenuSeparator(),
 				new ContextMenuAction() {
 					ActionType = ActionType.Exit,
@@ -163,6 +176,25 @@ namespace Mesen.Debugger.ViewModels
 			return null;
 		}
 
+		[Reactive] public string FilterLabel { get; set; } = "";
+		private AddressInfo? _filterAddress = null;
+
+		public void SetFilter(ProfiledFunction func, CpuType cpuType)
+		{
+			_filterAddress = func.Address;
+			FilterLabel = "Filter: " + func.GetFunctionName(cpuType);
+			DebugApi.SetProfilerFilter(CpuType, func.Address);
+			ResetData();
+		}
+
+		public void ClearFilter()
+		{
+			_filterAddress = null;
+			FilterLabel = "";
+			DebugApi.ClearProfilerFilter(CpuType);
+			ResetData();
+		}
+
 		public void ResetData()
 		{
 			DebugApi.ResetProfiler(CpuType);
@@ -188,7 +220,9 @@ namespace Mesen.Debugger.ViewModels
 			Sort();
 
 			UInt64 totalCycles = 0;
-			ProfiledFunction[] profilerData = _profilerData;
+			ProfiledFunction[] profilerData = HasFilter
+				? _profilerData.Where(f => f.InclusiveCycles > 0).ToArray()
+				: _profilerData;
 			foreach(ProfiledFunction f in profilerData) {
 				totalCycles += f.ExclusiveCycles;
 			}
@@ -202,6 +236,8 @@ namespace Mesen.Debugger.ViewModels
 				GridData[i].Update(profilerData[i], CpuType, _totalCycles);
 			}
 		}
+
+		public bool HasFilter => _filterAddress != null;
 
 		public void SortCommand(object? param)
 		{
@@ -270,6 +306,7 @@ namespace Mesen.Debugger.ViewModels
 			}
 		}
 
+		public ProfiledFunction FuncData => _funcData;
 		public string ExclusiveCycles { get; set; } = "";
 		public string InclusiveCycles { get; set; } = "";
 		public string CallCount { get; set; } = "";

--- a/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
@@ -59,7 +59,6 @@ namespace Mesen.Debugger.ViewModels
 				},
 				new ContextMenuAction() {
 					ActionType = ActionType.SetProfilerFilter,
-					IsEnabled = () => SelectedTab?.Selection.SelectedItem != null,
 					OnClick = () => {
 						var item = SelectedTab?.Selection.SelectedItem;
 						if(item != null && SelectedTab != null)

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -438,6 +438,9 @@ namespace Mesen.Interop
 			return callstack;
 		}
 
+		[DllImport(DllPath)] public static extern void SetProfilerFilter(CpuType type, AddressInfo addr);
+		[DllImport(DllPath)] public static extern void ClearProfilerFilter(CpuType type);
+
 		[DllImport(DllPath)] public static extern void ResetProfiler(CpuType type);
 		[DllImport(DllPath, EntryPoint = "GetProfilerData")] private static extern void GetProfilerDataWrapper(CpuType type, IntPtr profilerData, ref UInt32 functionCount);
 		public static unsafe int GetProfilerData(CpuType type, ref ProfiledFunction[] profilerData)

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -3690,6 +3690,8 @@ E
 
 			<Value ID="CopyToClipboard">Copy to clipboard</Value>
 			<Value ID="ResetProfilerData">Reset profiler data</Value>
+                        <Value ID="SetProfilerFilter">Set filter</Value>
+                        <Value ID="ClearProfilerFilter">Clear filter</Value>
 		</Enum>
 	</Enums>
 </Resources>

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -3690,7 +3690,7 @@ E
 
 			<Value ID="CopyToClipboard">Copy to clipboard</Value>
 			<Value ID="ResetProfilerData">Reset profiler data</Value>
-			<Value ID="SetProfilerFilter">Filter selected call graph</Value>
+			<Value ID="SetProfilerFilter">Set filter</Value>
 			<Value ID="ClearProfilerFilter">Clear filter</Value>
 		</Enum>
 	</Enums>

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -3690,8 +3690,8 @@ E
 
 			<Value ID="CopyToClipboard">Copy to clipboard</Value>
 			<Value ID="ResetProfilerData">Reset profiler data</Value>
-                        <Value ID="SetProfilerFilter">Set filter</Value>
-                        <Value ID="ClearProfilerFilter">Clear filter</Value>
+			<Value ID="SetProfilerFilter">Set filter</Value>
+			<Value ID="ClearProfilerFilter">Clear filter</Value>
 		</Enum>
 	</Enums>
 </Resources>

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -3690,7 +3690,7 @@ E
 
 			<Value ID="CopyToClipboard">Copy to clipboard</Value>
 			<Value ID="ResetProfilerData">Reset profiler data</Value>
-			<Value ID="SetProfilerFilter">Set filter</Value>
+			<Value ID="SetProfilerFilter">Filter selected call graph</Value>
 			<Value ID="ClearProfilerFilter">Clear filter</Value>
 		</Enum>
 	</Enums>


### PR DESCRIPTION
I do GBA homebrew development as a hobby, and I love the Mesen profiler! One feature that would be really nice to have, in my opinion, would be the option to filter the profiler window based on specific functions. One thing I find myself doing in Mesen, when profiling infrequently-called functions that create bottlenecks, is to set a breakpoint, clear the profiler window, and then step out, to view the overhead of a specific subtree of source code in the profiler, without the noise from all the other functions in my codebase. To save myself the trouble of messing around in the debugger every time, I added a feature to my fork of Mesen where you can select a function in the profiler window, click filter, and just see a latency breakdown of the filtered function and the functions that it calls.

I understand that you must be very busy, and I concede that I don't know C# very well, and I completely understand if you'd prefer not to merge these changes. I'd be happy to make any changes that you suggest to the diff.
I created this PR in case it'd be a feature that other people would find useful.