### PR TITLE
Add HiROM memory mapping support to GSU coprocessor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,256 @@
+# Driving Mesen-MCP from a coding agent
+
+Skim this once before you connect. It's the difference between "an LLM that uses
+Mesen well" and "an LLM that fights the harness for an hour and gives up."
+
+## What you're talking to
+
+A patched build of [Mesen2](https://github.com/SourMesen/Mesen2) launched as:
+
+```
+Mesen.exe --mcp [--mcp-port=N] /path/to/rom.sfc
+```
+
+It listens on `127.0.0.1:N` (default 7333), accepts **one client at a time**, and
+speaks newline-delimited JSON-RPC 2.0. Server stdout is the MCP channel; debugger
+log lines go to stderr. You can also load `.spc` files for SNES audio
+debugging — pass the `.spc` as the ROM path and the SPC700 starts playing
+immediately.
+
+## Connecting
+
+Quickest path is the bundled Python client:
+
+```python
+from mcp_client import McpSession  # tools/mcp_client.py in the SNES project
+
+with McpSession(rom='game.sfc') as m:
+    m.call('initialize', {})  # done by __enter__ already
+    print(m.call('tools/list')['result']['tools'])
+```
+
+If you're rolling your own client: do `initialize` first, then `tools/list`,
+then `tools/call`s. Reads from the socket can interleave with
+`notifications/mesen/hookFired` push messages — your client must keep a queue
+of those and not assume every line is a response to your last request.
+
+## Mental model: pause then read
+
+The single most common rookie mistake is treating Mesen like a static state.
+**It runs at max speed by default.** Two `read_memory` calls 50ms apart see
+totally different states. The fix:
+
+```python
+m.pause()
+state_a = m.read_memory("snesMemory", 0x7E0000, 256)
+state_b = m.read_memory("snesMemory", 0x7E0000, 256)  # same as state_a
+m.resume()
+```
+
+Always pause before a multi-call inspection. Or compose with `run_until` /
+`run_frames` if you need to advance and then inspect.
+
+## Tool cheat sheet
+
+```
+SESSION
+  initialize, shutdown, ping
+
+CONTROL
+  pause                                   pause emulation; reads stable now
+  resume                                  back to max speed
+  run_frames(count)                       advance ~count frames, then pause
+  run_until(maxFrames=600, hookHandle=N)  resume until hook fires or budget
+  reset_emulator(power=true)              full power-cycle (frame counter to 0)
+
+STATE
+  get_state                               isRunning, isPaused, frameCount
+  get_ppu_state                           BG layers, scroll, window mask
+  get_audio_state                         SPC700 + 8 voices' env/pitch/vol
+  read_dma_state                          all 8 DMA/HDMA channels decoded
+  hook_diag                               counters: how often hot path fired
+
+MEMORY
+  read_memory(memoryType, address, length)        hex-encoded bytes back
+  write_memory(memoryType, address, hex)          hex-encoded bytes in
+
+  memoryType: snesMemory  (CPU bus, $00:0000..$7F:FFFF)
+              snesWorkRam (just $7E:0000..$7F:FFFF)
+              snesVideoRam, snesCgRam, snesSpriteRam, snesPrgRom
+              sa1Memory (SA-1 chip's view), sa1IRam (3KB on-chip)
+
+HOOKS  (server pushes notifications/mesen/hookFired when these match)
+  add_exec_hook(address, endAddress?, matchValue?, matchValueMask?)
+  add_read_hook(...)        same shape, fires on memory read in range
+  add_write_hook(...)       same shape, fires on memory write in range
+  add_frame_hook(everyN=1)  fires once per video frame (or every Nth)
+  remove_hook(handle)
+  list_hooks
+
+  matchValueMask=0 disables value match (fire on every hit).
+  matchValueMask=0xFF + matchValue=33 means "fire only when value byte is 33".
+  Use this aggressively on hot addresses; otherwise the socket floods.
+
+SYMBOLS / DISASM
+  lookup_symbol(symFile, pattern, maxResults?)    regex match WLA-DX .sym
+  disassemble(address, count=16, cpuType="Snes")  N instructions from PC
+
+SCREENSHOTS
+  take_screenshot(format="path"|"base64")
+  crop_screenshot(x, y, width, height, format="path"|"base64")
+
+SAVE STATES
+  save_state(path) / load_state(path)            file-backed
+  save_state_slot(slot) / load_state_slot(slot)  numbered 0..9
+
+AUDIO
+  record_audio(path)        starts WAV capture; pair with stop_audio
+  stop_audio
+  get_audio_state           live SPC + DSP voice register snapshot
+
+INPUT
+  set_input(port, buttons, frames)
+    bitmask: a=1, b=2, select=4, start=8, up=16, down=32, left=64, right=128,
+             x=256, l=512, r=1024, y=2048
+    Holds the input for `frames` emulator frames, then releases.
+```
+
+## How notifications arrive
+
+When you register a hook, the server pushes JSON like:
+
+```json
+{"jsonrpc":"2.0","method":"notifications/mesen/hookFired","params":{
+  "handle": 1,
+  "kind": "Exec",
+  "cpuType": "Snes",
+  "address": 12845094,
+  "value": 162,
+  "frame": 188
+}}
+```
+
+These are interleaved with your tool responses. The Python client's
+`drain_notifications()` reads any pending ones into a list. If you roll your
+own, distinguish by presence of `"id"` (response) vs `"method"` (notification).
+
+## Common workflows
+
+### "Did the bug fire on this frame?"
+
+```python
+h = m.add_exec_hook(0xC04E2A)  # addr of the function you're suspicious of
+m.run_frames(500)
+hits = [n for n in m.drain_notifications() if n['params']['handle'] == h]
+print(f"function ran {len(hits)} times in 500 frames")
+m.remove_hook(h)
+```
+
+### "What's the SPC700 voice doing right now?"
+
+```python
+m.pause()
+s = m.get_audio_state()
+for v in s['voices']:
+    if v['envelope'] > 0:
+        print(f"voice {v['voice']}: pitch={v['pitch']} env={v['envelope']}")
+```
+
+### "Compare the recorded music to a reference"
+
+```python
+m.record_audio('/tmp/now.wav')
+m.run_frames(600)         # 10 seconds at 60fps; less wall-clock at max speed
+m.stop_audio()
+# offline:
+# python3 audio_analyze.py /tmp/now.wav --ref /tmp/expected.wav
+```
+
+The analyzer prints per-band dB delta — that's the objective signal "is this
+song right" without ears.
+
+### "Reach a known game state fast"
+
+Either:
+
+1. **Save state checkpoint**: do an expensive boot once, `save_state_slot(0)`,
+   then start every test with `load_state_slot(0)`.
+2. **`set_input` chain**: drive the menus with explicit START presses
+   from MCP rather than spamming raw `setInput` from Lua.
+
+Save states are ~10× faster than re-driving from boot.
+
+### "Diff state between two reproduction paths"
+
+When something renders differently in two code paths, capture every probeable
+state region in both and diff:
+
+```python
+def dump(m):
+    m.pause()
+    return {
+        'palette':  m.read_memory('snesCgRam', 0, 512),
+        'oam':      m.read_memory('snesSpriteRam', 0, 0x220),
+        'bg1tiles': m.read_memory('snesVideoRam', 0x0000, 0x7000),
+        'tilemap':  m.read_memory('snesVideoRam', 0x3000, 0x1000),
+        'ppu':      m.get_ppu_state(),
+        'dma':      m.read_dma_state(),
+    }
+
+clean   = dump(m_clean)
+corrupt = dump(m_corrupt)
+for k in clean:
+    if isinstance(clean[k], bytes) and clean[k] != corrupt[k]:
+        print(f"{k}: differs")
+```
+
+This pattern uncovered an HDMA + main-screen layer mismatch on the project
+this fork was built for. With Lua scripts it took a half-day; with this
+diff loop it took ten minutes.
+
+## Common gotchas
+
+- **Stderr will fill its pipe.** If you use `subprocess.PIPE` for stderr,
+  drain it in a thread. Mesen's debug logger (`[CPU] Uninitialized memory
+  read: ...`) emits hundreds of lines per second during the first ~12k
+  frames. A full stderr pipe blocks Mesen's `Console.Error.WriteLine`
+  inside the MCP handler, deadlocking the request loop. The provided
+  `mcp_client.py` does this correctly; copy that pattern.
+
+- **`run_frames(N)` is wall-clock approximate.** At max speed the emulator
+  runs many more frames than the requested count; we sleep for the
+  estimated 60Hz duration plus headroom. Use `get_state().frameCount`
+  for ground truth and compose with `run_until` if you need a hard
+  upper bound.
+
+- **VRAM reads are reliable when paused.** They're sometimes
+  flaky in SA-1 mode while running because of emulation thread races —
+  always `pause` first if you care about exact bytes.
+
+- **One client at a time.** The server accepts a new connection only
+  after the previous client disconnects. Hooks are reset on disconnect
+  so a crashed client doesn't leak watchpoints into the next session.
+
+- **Bounded event queue (4096).** A hook on a too-broad range will
+  drop oldest events rather than back-pressure the emulator. If you're
+  seeing fewer notifications than you expected, narrow the address
+  range or add a `matchValue` filter.
+
+## Where to read source
+
+- `Core/Mcp/McpHookManager.{h,cpp}` — the hot-path event manager.
+- `UI/Utilities/Mcp/McpServer.cs` — TCP accept loop + JSON-RPC dispatch.
+- `UI/Utilities/Mcp/McpTools.cs` — every tool's argument parsing + impl.
+- `UI/Utilities/Mcp/McpRunner.cs` — `--mcp` entry point.
+
+If you're adding a new tool, the diff is one entry in the `Descriptions`
+list, one entry in `BuildToolTable()`, one method on `McpTools`. Most
+existing tools are 5–30 lines.
+
+## Limitations / explicit non-goals (for now)
+
+- No movie record/playback yet. See [TheAnsarya/Nexen](https://github.com/TheAnsarya/Nexen)'s `.nexen-movie` format if you need this; it's a tracked task to add.
+- Frame-stepping uses wall-clock, not greenzone-style per-frame savestates. Tracked.
+- No interactive `step_into` / `step_over` like a native debugger UI. Use
+  exec hooks + `run_until` instead.
+- WLA-DX `.sym` only for `lookup_symbol` (no Pansy yet).

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -744,6 +744,7 @@
     <ClInclude Include="Debugger\ScriptHost.h" />
     <ClInclude Include="Debugger\ScriptingContext.h" />
     <ClInclude Include="Debugger\ScriptManager.h" />
+    <ClInclude Include="Mcp\McpHookManager.h" />
     <ClInclude Include="SNES\Coprocessors\SDD1\Sdd1.h" />
     <ClInclude Include="SNES\Coprocessors\SDD1\Sdd1Decomp.h" />
     <ClInclude Include="SNES\Coprocessors\SDD1\Sdd1Mmc.h" />
@@ -1067,6 +1068,7 @@
     <ClCompile Include="Debugger\ScriptHost.cpp" />
     <ClCompile Include="Debugger\ScriptingContext.cpp" />
     <ClCompile Include="Debugger\ScriptManager.cpp" />
+    <ClCompile Include="Mcp\McpHookManager.cpp" />
     <ClCompile Include="SNES\Coprocessors\SDD1\Sdd1.cpp" />
     <ClCompile Include="SNES\Coprocessors\SDD1\Sdd1Decomp.cpp" />
     <ClCompile Include="SNES\Coprocessors\SDD1\Sdd1Mmc.cpp" />

--- a/Core/Debugger/Debugger.cpp
+++ b/Core/Debugger/Debugger.cpp
@@ -601,6 +601,17 @@ void Debugger::ProcessEvent(EventType type, std::optional<CpuType> cpuTypeOpt)
 	CpuType evtCpuType = cpuTypeOpt.value_or(_mainCpuType);
 	_scriptManager->ProcessEvent(type, evtCpuType);
 
+	// MCP frame hooks: fire once per video frame on the main CPU only —
+	// SA-1 / SPC / etc. also raise EndFrame and would double-count. Pass
+	// the frame number as both addr and value so value-match filters
+	// (e.g. "every Nth frame") work uniformly.
+	if(type == EventType::EndFrame && evtCpuType == _mainCpuType
+			&& _mcpHooks->HasAnyHooks()) {
+		uint32_t frameNum = _emu->GetFrameCount();
+		_mcpHooks->OnMemoryOperation(evtCpuType, frameNum, frameNum,
+			McpHookKind::Frame, frameNum);
+	}
+
 	switch(type) {
 		default: break;
 

--- a/Core/Debugger/Debugger.cpp
+++ b/Core/Debugger/Debugger.cpp
@@ -12,6 +12,7 @@
 #include "Debugger/DebugBreakHelper.h"
 #include "Debugger/LabelManager.h"
 #include "Debugger/ScriptManager.h"
+#include "Mcp/McpHookManager.h"
 #include "Debugger/ScriptHost.h"
 #include "Debugger/CallstackManager.h"
 #include "Debugger/ExpressionEvaluator.h"
@@ -80,6 +81,7 @@ Debugger::Debugger(Emulator* emu, IConsole* console)
 	_disassemblySearch.reset(new DisassemblySearch(_disassembler.get(), _labelManager.get()));
 	_memoryAccessCounter.reset(new MemoryAccessCounter(this));
 	_scriptManager.reset(new ScriptManager(this));
+	_mcpHooks.reset(new McpHookManager());
 	_traceLogSaver.reset(new TraceLogFileSaver());
 	_cdlManager.reset(new CdlManager(this, _disassembler.get()));
 
@@ -245,6 +247,11 @@ void Debugger::ProcessInstruction()
 		AddressInfo relAddr = { (int32_t)memOp.Address, memOp.MemType };
 		uint8_t value = (uint8_t)memOp.Value;
 		_scriptManager->ProcessMemoryOperation(relAddr, value, MemoryOperationType::ExecOpCode, type, true);
+	}
+
+	if(_mcpHooks->HasAnyHooks()) {
+		MemoryOperationInfo memOp = debugger->InstructionProgress.LastMemOperation;
+		_mcpHooks->OnMemoryOperation(type, memOp.Address, memOp.Value, McpHookKind::Exec, _emu->GetFrameCount());
 	}
 }
 

--- a/Core/Debugger/Debugger.cpp
+++ b/Core/Debugger/Debugger.cpp
@@ -1052,7 +1052,13 @@ void Debugger::Log(string message)
 	}
 	_debuggerLog.push_back(message);
 
-	std::cout << message << std::endl;
+	// In MCP mode the parent process owns stdout for JSON-RPC framing;
+	// mirror the log line to stderr instead so humans can still see it.
+	if(_settings && _settings->CheckFlag(EmulationFlags::McpMode)) {
+		std::cerr << message << std::endl;
+	} else {
+		std::cout << message << std::endl;
+	}
 }
 
 string Debugger::GetLog()

--- a/Core/Debugger/Debugger.cpp
+++ b/Core/Debugger/Debugger.cpp
@@ -286,6 +286,10 @@ void Debugger::ProcessMemoryRead(uint32_t addr, T& value, MemoryOperationType op
 	if(_scriptManager->HasCpuMemoryCallbacks()) {
 		ProcessScripts<type>(addr, value, opType);
 	}
+
+	if(_mcpHooks->HasAnyHooks()) {
+		_mcpHooks->OnMemoryOperation(type, addr, (uint32_t)value, McpHookKind::Read, _emu->GetFrameCount());
+	}
 }
 
 template<CpuType type, uint8_t accessWidth, MemoryAccessFlags flags, typename T>
@@ -319,7 +323,11 @@ bool Debugger::ProcessMemoryWrite(uint32_t addr, T& value, MemoryOperationType o
 	if(_scriptManager->HasCpuMemoryCallbacks()) {
 		ProcessScripts<type>(addr, value, opType);
 	}
-	
+
+	if(_mcpHooks->HasAnyHooks()) {
+		_mcpHooks->OnMemoryOperation(type, addr, (uint32_t)value, McpHookKind::Write, _emu->GetFrameCount());
+	}
+
 	return !_debuggers[(int)type].Debugger->GetFrozenAddressManager().IsFrozenAddress(addr);
 }
 

--- a/Core/Debugger/Debugger.h
+++ b/Core/Debugger/Debugger.h
@@ -65,6 +65,7 @@ private:
 	ConsoleType _consoleType = ConsoleType::Snes;
 
 	unique_ptr<ScriptManager> _scriptManager;
+	unique_ptr<class McpHookManager> _mcpHooks;
 	unique_ptr<MemoryDumper> _memoryDumper;
 	unique_ptr<MemoryAccessCounter> _memoryAccessCounter;
 	unique_ptr<CodeDataLogger> _codeDataLogger;
@@ -192,6 +193,7 @@ public:
 	LabelManager* GetLabelManager() { return _labelManager.get(); }
 	CdlManager* GetCdlManager() { return _cdlManager.get(); }
 	ScriptManager* GetScriptManager() { return _scriptManager.get(); }
+	class McpHookManager* GetMcpHooks() { return _mcpHooks.get(); }
 	IConsole* GetConsole() { return _console; }
 	Emulator* GetEmulator() { return _emu; }
 

--- a/Core/Debugger/ScriptingContext.cpp
+++ b/Core/Debugger/ScriptingContext.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include <algorithm>
+#include <iostream>
 #include <regex>
 #include "Lua/lua.hpp"
 #include "Lua/luasocket.hpp"
@@ -168,6 +169,13 @@ void ScriptingContext::Log(string message)
 	_logRows.push_back(message);
 	if(_logRows.size() > 500) {
 		_logRows.pop_front();
+	}
+	// MCP mode owns stdout for JSON-RPC framing; redirect Lua log output to
+	// stderr so it stays visible without corrupting the MCP channel.
+	if(_settings && _settings->CheckFlag(EmulationFlags::McpMode)) {
+		std::cerr << message << std::endl;
+	} else {
+		std::cout << message << std::endl;
 	}
 }
 

--- a/Core/Mcp/McpHookManager.cpp
+++ b/Core/Mcp/McpHookManager.cpp
@@ -5,17 +5,21 @@ McpHookManager::McpHookManager()
 {
 }
 
-int32_t McpHookManager::RegisterExecHook(CpuType cpu, uint32_t startAddr, uint32_t endAddr)
+int32_t McpHookManager::RegisterHook(McpHookKind kind, CpuType cpu, uint32_t startAddr, uint32_t endAddr,
+	uint32_t matchValue, uint32_t matchValueMask)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 	int32_t handle = _nextHandle.fetch_add(1);
 	McpHook h;
 	h.Handle = handle;
-	h.Kind = McpHookKind::Exec;
+	h.Kind = kind;
 	h.Cpu = cpu;
 	h.StartAddr = startAddr;
 	h.EndAddr = endAddr;
+	h.MatchValue = matchValue;
+	h.MatchValueMask = matchValueMask;
 	h.Active = true;
+	h.ValueMatchEnabled = (matchValueMask != 0);
 	_hooks.push_back(h);
 	UpdateHasAnyFlag();
 	return handle;
@@ -62,6 +66,9 @@ void McpHookManager::OnMemoryOperation(CpuType cpu, uint32_t addr, uint32_t valu
 		if(h.Kind != kind) continue;
 		if(h.Cpu != cpu) continue;
 		if(addr < h.StartAddr || addr > h.EndAddr) continue;
+		if(h.ValueMatchEnabled) {
+			if((value & h.MatchValueMask) != (h.MatchValue & h.MatchValueMask)) continue;
+		}
 		_matchCount.fetch_add(1, std::memory_order_relaxed);
 
 		// Drop oldest if queue full. Slow-client backpressure belongs on

--- a/Core/Mcp/McpHookManager.cpp
+++ b/Core/Mcp/McpHookManager.cpp
@@ -1,0 +1,113 @@
+#include "pch.h"
+#include "Mcp/McpHookManager.h"
+
+McpHookManager::McpHookManager()
+{
+}
+
+int32_t McpHookManager::RegisterExecHook(CpuType cpu, uint32_t startAddr, uint32_t endAddr)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	int32_t handle = _nextHandle.fetch_add(1);
+	McpHook h;
+	h.Handle = handle;
+	h.Kind = McpHookKind::Exec;
+	h.Cpu = cpu;
+	h.StartAddr = startAddr;
+	h.EndAddr = endAddr;
+	h.Active = true;
+	_hooks.push_back(h);
+	UpdateHasAnyFlag();
+	return handle;
+}
+
+bool McpHookManager::UnregisterHook(int32_t handle)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	for(auto it = _hooks.begin(); it != _hooks.end(); ++it) {
+		if(it->Handle == handle) {
+			_hooks.erase(it);
+			UpdateHasAnyFlag();
+			return true;
+		}
+	}
+	return false;
+}
+
+size_t McpHookManager::CopyActiveHooks(McpHook* out, size_t maxCount)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	size_t n = std::min(_hooks.size(), maxCount);
+	for(size_t i = 0; i < n; i++) {
+		out[i] = _hooks[i];
+	}
+	return n;
+}
+
+void McpHookManager::OnMemoryOperation(CpuType cpu, uint32_t addr, uint32_t value,
+	McpHookKind kind, uint32_t frameNumber)
+{
+	_callCount.fetch_add(1, std::memory_order_relaxed);
+
+	// Double-checked fast path: HasAnyHooks was true when we entered the
+	// caller, but another thread may have cleared all hooks since. The
+	// mutex-guarded loop below handles the empty case harmlessly.
+	std::lock_guard<std::mutex> lock(_mutex);
+	if(_hooks.empty()) {
+		return;
+	}
+
+	for(const McpHook& h : _hooks) {
+		if(!h.Active) continue;
+		if(h.Kind != kind) continue;
+		if(h.Cpu != cpu) continue;
+		if(addr < h.StartAddr || addr > h.EndAddr) continue;
+		_matchCount.fetch_add(1, std::memory_order_relaxed);
+
+		// Drop oldest if queue full. Slow-client backpressure belongs on
+		// the client, not on the emulator thread.
+		while(_events.size() >= MaxQueuedEvents) {
+			_events.pop_front();
+			_droppedEvents++;
+		}
+
+		McpHookEvent evt;
+		evt.Handle = h.Handle;
+		evt.Address = addr;
+		evt.Value = value;
+		evt.FrameNumber = frameNumber;
+		evt.Kind = (uint8_t)kind;
+		evt.Cpu = (uint8_t)cpu;
+		evt.Padding[0] = 0;
+		evt.Padding[1] = 0;
+		_events.push_back(evt);
+	}
+}
+
+size_t McpHookManager::DrainEvents(McpHookEvent* out, size_t maxCount)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	size_t n = std::min(_events.size(), maxCount);
+	for(size_t i = 0; i < n; i++) {
+		out[i] = _events.front();
+		_events.pop_front();
+	}
+	return n;
+}
+
+void McpHookManager::Reset()
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	_hooks.clear();
+	_events.clear();
+	_droppedEvents = 0;
+	_callCount.store(0, std::memory_order_relaxed);
+	_matchCount.store(0, std::memory_order_relaxed);
+	UpdateHasAnyFlag();
+}
+
+void McpHookManager::UpdateHasAnyFlag()
+{
+	// Caller must hold _mutex.
+	_hasAny.store(!_hooks.empty(), std::memory_order_relaxed);
+}

--- a/Core/Mcp/McpHookManager.h
+++ b/Core/Mcp/McpHookManager.h
@@ -12,6 +12,8 @@
 enum class McpHookKind : uint8_t
 {
 	Exec = 0,
+	Read = 1,
+	Write = 2,
 };
 
 struct McpHook
@@ -21,7 +23,13 @@ struct McpHook
 	CpuType Cpu;
 	uint32_t StartAddr;
 	uint32_t EndAddr;
+	// Optional value match. If ValueMatchEnabled, only fire when the
+	// observed value equals MatchValue (modulo MatchValueMask). Lets us
+	// suppress notification floods on hot PCs / hot memory ranges.
+	uint32_t MatchValue;
+	uint32_t MatchValueMask;
 	bool Active;
+	bool ValueMatchEnabled;
 };
 
 // Event emitted when a hook fires. Kept POD + fixed-size so the C# side
@@ -56,8 +64,10 @@ public:
 
 	McpHookManager();
 
-	// Registry.
-	int32_t RegisterExecHook(CpuType cpu, uint32_t startAddr, uint32_t endAddr);
+	// Registry. valueMatchMask=0 disables the value match (fire on every
+	// hit); valueMatchMask=0xFFFFFFFF requires exact equality.
+	int32_t RegisterHook(McpHookKind kind, CpuType cpu, uint32_t startAddr, uint32_t endAddr,
+		uint32_t matchValue = 0, uint32_t matchValueMask = 0);
 	bool UnregisterHook(int32_t handle);
 	size_t CopyActiveHooks(McpHook* out, size_t maxCount);
 

--- a/Core/Mcp/McpHookManager.h
+++ b/Core/Mcp/McpHookManager.h
@@ -1,0 +1,98 @@
+#pragma once
+#include "pch.h"
+#include "Debugger/DebugTypes.h"
+#include "Utilities/SimpleLock.h"
+#include <atomic>
+#include <deque>
+#include <mutex>
+#include <vector>
+
+// Hook kinds. Kept simple — phase-3 MVP is exec-on-CPU only; read/write/
+// scanline/frame can slot in as new HookKind values without churn.
+enum class McpHookKind : uint8_t
+{
+	Exec = 0,
+};
+
+struct McpHook
+{
+	int32_t Handle;
+	McpHookKind Kind;
+	CpuType Cpu;
+	uint32_t StartAddr;
+	uint32_t EndAddr;
+	bool Active;
+};
+
+// Event emitted when a hook fires. Kept POD + fixed-size so the C# side
+// can marshal a contiguous array in one P/Invoke.
+struct McpHookEvent
+{
+	int32_t Handle;
+	uint32_t Address;
+	uint32_t Value;       // 0 for exec hooks
+	uint32_t FrameNumber;
+	uint8_t Kind;         // McpHookKind
+	uint8_t Cpu;          // CpuType
+	uint8_t Padding[2];
+};
+
+// Thread-safe registry + bounded event queue. Hot path runs on the
+// emulator thread (called from Debugger::ProcessMemoryRead/Write/Instruction
+// via ProcessMemoryOperation). Drain runs on the MCP server thread.
+//
+// Design:
+// - RegisterHook/UnregisterHook hold a mutex. Modifications are rare.
+// - HasAnyHooks() is a cheap atomic read the hot path can use BEFORE it
+//   even considers taking the mutex (same trick as ScriptManager).
+// - OnMemoryOperation takes the mutex only if HasAnyHooks() is true.
+// - Events enqueue under the same mutex. Bounded queue drops oldest if
+//   full — a disconnected or slow client should not pressure the
+//   emulator thread or consume unbounded memory.
+class McpHookManager
+{
+public:
+	static constexpr size_t MaxQueuedEvents = 4096;
+
+	McpHookManager();
+
+	// Registry.
+	int32_t RegisterExecHook(CpuType cpu, uint32_t startAddr, uint32_t endAddr);
+	bool UnregisterHook(int32_t handle);
+	size_t CopyActiveHooks(McpHook* out, size_t maxCount);
+
+	// Hot-path fast check. emulator thread.
+	bool HasAnyHooks() const { return _hasAny.load(std::memory_order_relaxed); }
+
+	// Diagnostic: total matches since last reset, and total OnMemoryOperation
+	// invocations (regardless of match). Lets a client confirm the hot-path
+	// integration is alive even if no hook address range matches.
+	uint64_t GetCallCount() const { return _callCount.load(std::memory_order_relaxed); }
+	uint64_t GetMatchCount() const { return _matchCount.load(std::memory_order_relaxed); }
+
+	// Fire from emulator thread. Synchronously matches the op against all
+	// registered hooks and pushes one event per match. Drops oldest events
+	// if queue is full.
+	void OnMemoryOperation(CpuType cpu, uint32_t addr, uint32_t value,
+		McpHookKind kind, uint32_t frameNumber);
+
+	// Drain events into out buffer. Returns number of events copied.
+	// Emulator thread continues enqueueing concurrently; draining is O(n).
+	size_t DrainEvents(McpHookEvent* out, size_t maxCount);
+
+	// Clear all hooks + events. Called on MCP client disconnect so a crashed
+	// client does not leak hooks into the running emulator.
+	void Reset();
+
+private:
+	void UpdateHasAnyFlag();
+
+	std::mutex _mutex;
+	std::vector<McpHook> _hooks;
+	std::deque<McpHookEvent> _events;
+	std::atomic<bool> _hasAny{false};
+	std::atomic<int32_t> _nextHandle{1};
+	std::atomic<uint64_t> _callCount{0};
+	std::atomic<uint64_t> _matchCount{0};
+	size_t _droppedEvents = 0;
+};

--- a/Core/Mcp/McpHookManager.h
+++ b/Core/Mcp/McpHookManager.h
@@ -14,6 +14,7 @@ enum class McpHookKind : uint8_t
 	Exec = 0,
 	Read = 1,
 	Write = 2,
+	Frame = 3,
 };
 
 struct McpHook

--- a/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
@@ -5,6 +5,10 @@
 
 void Gsu::STOP()
 {
+	// Flush pixel caches before stopping
+	WritePixelCache(_state.SecondaryCache);
+	WritePixelCache(_state.PrimaryCache);
+
 	if(!_state.IrqDisabled) {
 		_state.SFR.Irq = true;
 		_cpu->SetIrqSource(SnesIrqSource::Coprocessor);

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -6,6 +6,7 @@
 #include "SNES/SnesCpu.h"
 #include "SNES/SnesMemoryManager.h"
 #include "SNES/BaseCartridge.h"
+#include "SNES/CartTypes.h"
 #include "SNES/RamHandler.h"
 #include "Shared/Emulator.h"
 #include "Shared/EmuSettings.h"
@@ -39,7 +40,7 @@ Gsu::Gsu(SnesConsole *console, uint32_t gsuRamSize)
 		_gsuRamHandlers.push_back(unique_ptr<IMemoryHandler>(new RamHandler(_gsuRam, i * 0x1000, _gsuRamSize, MemoryType::GsuWorkRam)));
 		_gsuCpuRamHandlers.push_back(unique_ptr<IMemoryHandler>(new GsuRamHandler(_state, _gsuRamHandlers.back().get())));
 	}
-	
+
 	//CPU mappings
 	MemoryMappings *cpuMappings = _memoryManager->GetMemoryMappings();
 	vector<unique_ptr<IMemoryHandler>> &prgRomHandlers = _console->GetCartridge()->GetPrgRomHandlers();
@@ -51,25 +52,68 @@ Gsu::Gsu(SnesConsole *console, uint32_t gsuRamSize)
 	cpuMappings->RegisterHandler(0x00, 0x3F, 0x3000, 0x3FFF, this);
 	cpuMappings->RegisterHandler(0x80, 0xBF, 0x3000, 0x3FFF, this);
 
-	for(int i = 0; i < 0x3F; i++) {
-		cpuMappings->RegisterHandler(i, i, 0x6000, 0x7FFF, _gsuCpuRamHandlers);
-		cpuMappings->RegisterHandler(i + 0x80, i + 0x80, 0x6000, 0x7FFF, _gsuCpuRamHandlers);
+	bool isHiRom = (_console->GetCartridge()->GetCartFlags() & CartFlags::HiRom) != 0;
+
+	if(isHiRom) {
+		//HiROM+GSU: use pageIncrement=8 so $00:$8000 maps to ROM offset $8000 (not $0000)
+		cpuMappings->RegisterHandler(0x00, 0x3F, 0x8000, 0xFFFF, _gsuCpuRomHandlers, 8);
+		cpuMappings->RegisterHandler(0x80, 0xBF, 0x8000, 0xFFFF, _gsuCpuRomHandlers, 8);
+		//ROM at $40-$7D, skipping $70-$71 (GSU RAM banks)
+		cpuMappings->RegisterHandler(0x40, 0x6F, 0x0000, 0xFFFF, _gsuCpuRomHandlers);
+		uint16_t startPage72 = (uint16_t)(((0x72 - 0x40) * 16) % _gsuCpuRomHandlers.size());
+		cpuMappings->RegisterHandler(0x72, 0x7D, 0x0000, 0xFFFF, _gsuCpuRomHandlers, 0, startPage72);
+		//ROM at $C0-$FF, skipping $F0-$F1 (GSU RAM mirrors)
+		cpuMappings->RegisterHandler(0xC0, 0xEF, 0x0000, 0xFFFF, _gsuCpuRomHandlers);
+		uint16_t startPageF2 = (uint16_t)(((0xF2 - 0xC0) * 16) % _gsuCpuRomHandlers.size());
+		cpuMappings->RegisterHandler(0xF2, 0xFF, 0x0000, 0xFFFF, _gsuCpuRomHandlers, 0, startPageF2);
+
+		//GSU-side ROM: HiROM layout (linear 64KB per bank)
+		_mappings.RegisterHandler(0x00, 0x3F, 0x0000, 0xFFFF, prgRomHandlers);
+		_mappings.RegisterHandler(0x40, 0x5F, 0x0000, 0xFFFF, prgRomHandlers);
+	} else {
+		//LoROM+GSU: EXACT original Mesen mapping (order matters)
+		for(int i = 0; i < 0x3F; i++) {
+			cpuMappings->RegisterHandler(i, i, 0x6000, 0x7FFF, _gsuCpuRamHandlers);
+			cpuMappings->RegisterHandler(i + 0x80, i + 0x80, 0x6000, 0x7FFF, _gsuCpuRamHandlers);
+		}
+		cpuMappings->RegisterHandler(0x70, 0x71, 0x0000, 0xFFFF, _gsuCpuRamHandlers);
+		cpuMappings->RegisterHandler(0xF0, 0xF1, 0x0000, 0xFFFF, _gsuCpuRamHandlers);
+
+		cpuMappings->RegisterHandler(0x00, 0x3F, 0x8000, 0xFFFF, _gsuCpuRomHandlers);
+		cpuMappings->RegisterHandler(0x80, 0xBF, 0x8000, 0xFFFF, _gsuCpuRomHandlers);
+		cpuMappings->RegisterHandler(0x40, 0x5F, 0x0000, 0xFFFF, _gsuCpuRomHandlers);
+		cpuMappings->RegisterHandler(0xC0, 0xDF, 0x0000, 0xFFFF, _gsuCpuRomHandlers);
+
+		//GSU-side ROM: LoROM layout
+		_mappings.RegisterHandler(0x00, 0x3F, 0x8000, 0xFFFF, prgRomHandlers);
+		_mappings.RegisterHandler(0x00, 0x3F, 0x0000, 0x7FFF, prgRomHandlers); //Mirror
+		_mappings.RegisterHandler(0x40, 0x5F, 0x0000, 0xFFFF, prgRomHandlers);
+
+		//GSU-side RAM
+		_mappings.RegisterHandler(0x70, 0x71, 0x0000, 0xFFFF, _gsuRamHandlers);
 	}
-	cpuMappings->RegisterHandler(0x70, 0x71, 0x0000, 0xFFFF, _gsuCpuRamHandlers);
-	cpuMappings->RegisterHandler(0xF0, 0xF1, 0x0000, 0xFFFF, _gsuCpuRamHandlers);
 
-	cpuMappings->RegisterHandler(0x00, 0x3F, 0x8000, 0xFFFF, _gsuCpuRomHandlers);
-	cpuMappings->RegisterHandler(0x80, 0xBF, 0x8000, 0xFFFF, _gsuCpuRomHandlers);
+	if(isHiRom) {
+		//HiROM RAM — registered AFTER ROM so $70-$71 overrides ROM
+		for(int i = 0; i < 0x3F; i++) {
+			cpuMappings->RegisterHandler(i, i, 0x6000, 0x7FFF, _gsuCpuRamHandlers);
+			cpuMappings->RegisterHandler(i + 0x80, i + 0x80, 0x6000, 0x7FFF, _gsuCpuRamHandlers);
+		}
+		for(uint8_t bank = 0x70; bank <= 0x71; bank++) {
+			for(uint32_t addr = 0x0000; addr <= 0xF000; addr += 0x1000) {
+				uint32_t ramPage = ((bank - 0x70) * 16 + (addr >> 12)) % _gsuCpuRamHandlers.size();
+				cpuMappings->RegisterHandler(bank, bank, (uint16_t)addr, (uint16_t)(addr | 0x0FFF), _gsuCpuRamHandlers[ramPage].get());
+			}
+		}
+		for(uint8_t bank = 0xF0; bank <= 0xF1; bank++) {
+			for(uint32_t addr = 0x0000; addr <= 0xF000; addr += 0x1000) {
+				uint32_t ramPage = ((bank - 0xF0) * 16 + (addr >> 12)) % _gsuCpuRamHandlers.size();
+				cpuMappings->RegisterHandler(bank, bank, (uint16_t)addr, (uint16_t)(addr | 0x0FFF), _gsuCpuRamHandlers[ramPage].get());
+			}
+		}
+		_mappings.RegisterHandler(0x70, 0x71, 0x0000, 0xFFFF, _gsuRamHandlers);
+	}
 
-	cpuMappings->RegisterHandler(0x40, 0x5F, 0x0000, 0xFFFF, _gsuCpuRomHandlers);
-	cpuMappings->RegisterHandler(0xC0, 0xDF, 0x0000, 0xFFFF, _gsuCpuRomHandlers);
-
-	//GSU mappings
-	_mappings.RegisterHandler(0x00, 0x3F, 0x8000, 0xFFFF, prgRomHandlers);
-	_mappings.RegisterHandler(0x00, 0x3F, 0x0000, 0x7FFF, prgRomHandlers); //Mirror
-
-	_mappings.RegisterHandler(0x40, 0x5F, 0x0000, 0xFFFF, prgRomHandlers);
-	_mappings.RegisterHandler(0x70, 0x71, 0x0000, 0xFFFF, _gsuRamHandlers);
 }
 
 Gsu::~Gsu()

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -429,8 +429,12 @@ void Gsu::WaitRamOperation()
 void Gsu::WaitForRomAccess()
 {
 	if(!_state.GsuRomAccess) {
-		_waitForRomAccess = true;
-		_stopped = true;
+		// When executing from RAM (PBR >= $60), the R14 ROM prefetch is
+		// a no-op on real hardware — don't stall the GSU for it.
+		if(_state.ProgramBank <= 0x5F) {
+			_waitForRomAccess = true;
+			_stopped = true;
+		}
 	}
 }
 
@@ -474,7 +478,8 @@ void Gsu::Step(uint64_t cycles)
 	_state.CycleCount += cycles;
 
 	if(_state.RomDelay) {
-		_state.RomDelay -= std::min<uint8_t>((uint8_t)cycles, _state.RomDelay);
+		uint8_t romDec = (cycles >= _state.RomDelay) ? _state.RomDelay : (uint8_t)cycles;
+		_state.RomDelay -= romDec;
 		if(_state.RomDelay == 0) {
 			WaitForRomAccess();
 			_state.RomReadBuffer = ReadGsu((_state.RomBank << 16) | _state.R[14], MemoryOperationType::Read);
@@ -483,7 +488,8 @@ void Gsu::Step(uint64_t cycles)
 	}
 
 	if(_state.RamDelay) {
-		_state.RamDelay -= std::min<uint8_t>((uint8_t)cycles, _state.RamDelay);
+		uint8_t ramDec = (cycles >= _state.RamDelay) ? _state.RamDelay : (uint8_t)cycles;
+		_state.RamDelay -= ramDec;
 		if(_state.RamDelay == 0) {
 			WaitForRamAccess();
 			WriteGsu(0x700000 | (_state.RamBank << 16) | _state.RamWriteAddress, _state.RamWriteValue, MemoryOperationType::Write);
@@ -571,6 +577,21 @@ void Gsu::Write(uint32_t addr, uint8_t value)
 				_state.RomDelay = _state.ClockSelect ? 5 : 6;
 			} else if(addr == 0x301F) {
 				_state.SFR.Running = true;
+				_waitForRomAccess = false;
+				_waitForRamAccess = false;
+				_state.SFR.RomReadPending = false;
+				_state.RomDelay = 0;
+				_state.RamDelay = 0;
+				// Note: do NOT clear _cacheValid here. Real hardware preserves
+				// the instruction cache across STOP/GO. Programs that need fresh
+				// cache should use the CACHE instruction with a different CacheBase.
+				// Ensure CycleCount doesn't exceed master clock so Run() can execute
+				{
+					uint64_t target = _memoryManager->GetMasterClock() * _clockMultiplier;
+					if(_state.CycleCount > target) {
+						_state.CycleCount = target;
+					}
+				}
 				UpdateRunningState();
 			}
 			break;

--- a/Core/Shared/SettingTypes.h
+++ b/Core/Shared/SettingTypes.h
@@ -12,6 +12,9 @@ enum class EmulationFlags
 	ConsoleMode = 0x10,
 	TestMode = 0x20,
 	OutputToStdout = 0x40,
+	// Mesen takes over stdout for MCP JSON-RPC framing; Debugger::Log and
+	// ScriptingContext::Log redirect to stderr when this bit is set.
+	McpMode = 0x80,
 };
 
 enum class ScaleFilterType

--- a/InteropDLL/DebugApiWrapper.cpp
+++ b/InteropDLL/DebugApiWrapper.cpp
@@ -91,9 +91,11 @@ extern "C"
 	DllExport void __stdcall SetInputOverrides(uint32_t index, DebugControllerState state) { WithDebugger(void, SetInputOverrides(index, state)); }
 
 	// --- MCP hook management --------------------------------------------
-	DllExport int32_t __stdcall McpAddExecHook(CpuType cpu, uint32_t startAddr, uint32_t endAddr)
+	DllExport int32_t __stdcall McpAddHook(uint8_t kind, CpuType cpu, uint32_t startAddr, uint32_t endAddr,
+		uint32_t matchValue, uint32_t matchValueMask)
 	{
-		return WithDebugger(int32_t, GetMcpHooks()->RegisterExecHook(cpu, startAddr, endAddr));
+		return WithDebugger(int32_t, GetMcpHooks()->RegisterHook(
+			(McpHookKind)kind, cpu, startAddr, endAddr, matchValue, matchValueMask));
 	}
 
 	DllExport bool __stdcall McpRemoveHook(int32_t handle)

--- a/InteropDLL/DebugApiWrapper.cpp
+++ b/InteropDLL/DebugApiWrapper.cpp
@@ -16,6 +16,7 @@
 #include "Core/Debugger/CallstackManager.h"
 #include "Core/Debugger/LabelManager.h"
 #include "Core/Debugger/ScriptManager.h"
+#include "Core/Mcp/McpHookManager.h"
 #include "Core/Debugger/Profiler.h"
 #include "Core/Debugger/IAssembler.h"
 #include "Core/Debugger/BaseEventManager.h"
@@ -88,6 +89,48 @@ extern "C"
 	DllExport void __stdcall SetBreakpoints(Breakpoint breakpoints[], uint32_t length) { WithDebugger(void, SetBreakpoints(breakpoints, length)); }
 	
 	DllExport void __stdcall SetInputOverrides(uint32_t index, DebugControllerState state) { WithDebugger(void, SetInputOverrides(index, state)); }
+
+	// --- MCP hook management --------------------------------------------
+	DllExport int32_t __stdcall McpAddExecHook(CpuType cpu, uint32_t startAddr, uint32_t endAddr)
+	{
+		return WithDebugger(int32_t, GetMcpHooks()->RegisterExecHook(cpu, startAddr, endAddr));
+	}
+
+	DllExport bool __stdcall McpRemoveHook(int32_t handle)
+	{
+		return WithDebugger(bool, GetMcpHooks()->UnregisterHook(handle));
+	}
+
+	DllExport int32_t __stdcall McpListHooks(McpHook* out, int32_t maxCount)
+	{
+		if(maxCount <= 0) return 0;
+		return (int32_t)WithDebugger(size_t, GetMcpHooks()->CopyActiveHooks(out, (size_t)maxCount));
+	}
+
+	DllExport int32_t __stdcall McpDrainEvents(McpHookEvent* out, int32_t maxCount)
+	{
+		if(maxCount <= 0) return 0;
+		return (int32_t)WithDebugger(size_t, GetMcpHooks()->DrainEvents(out, (size_t)maxCount));
+	}
+
+	DllExport void __stdcall McpResetHooks()
+	{
+		WithDebugger(void, GetMcpHooks()->Reset());
+	}
+
+	DllExport void __stdcall McpHookDiagCounters(uint64_t* calls, uint64_t* matches)
+	{
+		DebuggerRequest dbgRequest = _emu->GetDebugger(true);
+		if(Debugger* dbg = dbgRequest.GetDebugger()) {
+			if(calls) *calls = dbg->GetMcpHooks()->GetCallCount();
+			if(matches) *matches = dbg->GetMcpHooks()->GetMatchCount();
+		} else {
+			if(calls) *calls = 0;
+			if(matches) *matches = 0;
+		}
+	}
+
+
 	DllExport void __stdcall GetAvailableInputOverrides(uint8_t* availableIndexes) { WithDebugger(void, GetAvailableInputOverrides(availableIndexes)); }
 	
 	DllExport void __stdcall GetTokenList(CpuType cpuType, char* tokenList) { WithDebugger(void, GetTokenList(cpuType, tokenList)); }

--- a/InteropDLL/EmuApiWrapper.cpp
+++ b/InteropDLL/EmuApiWrapper.cpp
@@ -174,6 +174,9 @@ extern "C" {
 
 	DllExport uint32_t __stdcall GetFrameCount() { return _emu->GetFrameCount(); }
 
+	DllExport void __stdcall McpResetEmu() { _emu->Reset(); }
+	DllExport void __stdcall McpPowerCycle() { _emu->PowerCycle(); }
+
 	DllExport void __stdcall ProcessAudioPlayerAction(AudioPlayerActionParams p) { _emu->ProcessAudioPlayerAction(p); }
 
 	DllExport void __stdcall GetArchiveRomList(char* filename, char* outBuffer, uint32_t maxLength) { 

--- a/InteropDLL/EmuApiWrapper.cpp
+++ b/InteropDLL/EmuApiWrapper.cpp
@@ -172,6 +172,8 @@ extern "C" {
 
 	DllExport void __stdcall TakeScreenshot() { _emu->GetVideoDecoder()->TakeScreenshot(); }
 
+	DllExport uint32_t __stdcall GetFrameCount() { return _emu->GetFrameCount(); }
+
 	DllExport void __stdcall ProcessAudioPlayerAction(AudioPlayerActionParams p) { _emu->ProcessAudioPlayerAction(p); }
 
 	DllExport void __stdcall GetArchiveRomList(char* filename, char* outBuffer, uint32_t maxLength) { 

--- a/InteropDLL/EmuApiWrapper.cpp
+++ b/InteropDLL/EmuApiWrapper.cpp
@@ -12,6 +12,8 @@
 #include "Core/Shared/TimingInfo.h"
 #include "Core/Shared/CheatManager.h"
 #include "Core/Shared/DebuggerRequest.h"
+#include "Core/Debugger/Debugger.h"
+#include "Core/Debugger/ScriptManager.h"
 #include "Core/Netplay/GameClient.h"
 #include "Core/Netplay/GameServer.h"
 #include "Utilities/ArchiveReader.h"
@@ -311,6 +313,53 @@ extern "C" {
 		void ResetKeyState() {}
 		void SetDisabled(bool disabled) {}
 	};
+
+	DllExport int32_t __stdcall HeadlessRunTest(char* romPath, char* homeFolder,
+		char* luaName, char* luaDir, char* luaContent, int32_t timeoutSec)
+	{
+		FolderUtilities::SetHomeFolder(homeFolder);
+		KeyManager::SetSettings(_emu->GetSettings());
+		_emu->Initialize();
+
+		_emu->GetSettings()->SetFlag(EmulationFlags::ConsoleMode);
+		_emu->GetSettings()->SetFlag(EmulationFlags::MaximumSpeed);
+		_emu->GetSettings()->SetFlag(EmulationFlags::OutputToStdout);
+
+		if(!_emu->LoadRom((VirtualFile)string(romPath), VirtualFile())) {
+			_emu->Stop(false);
+			_emu->Release();
+			return -2;
+		}
+
+		if(luaContent != nullptr && strlen(luaContent) > 0) {
+			DebuggerRequest dbgReq = _emu->GetDebugger(false);
+			Debugger* dbg = dbgReq.GetDebugger();
+			if(dbg && dbg->GetScriptManager()) {
+				dbg->GetScriptManager()->LoadScript(
+					string(luaName), string(luaDir), string(luaContent), -1);
+			}
+		}
+
+		int32_t result = -1;
+		auto start = std::chrono::steady_clock::now();
+		while(true) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+				std::chrono::steady_clock::now() - start).count();
+
+			if(!_emu->IsRunning()) {
+				result = _emu->GetStopCode();
+				break;
+			}
+			if(elapsed >= timeoutSec) {
+				break;
+			}
+		}
+
+		_emu->Stop(false);
+		_emu->Release();
+		return result;
+	}
 
 	DllExport void __stdcall PgoRunTest(vector<string> testRoms, bool enableDebugger)
 	{

--- a/README.md
+++ b/README.md
@@ -1,60 +1,104 @@
-# Mesen
+# Mesen-MCP
 
-Mesen is a multi-system emulator (NES, SNES, Game Boy, Game Boy Advance, PC Engine, SMS/Game Gear, WonderSwan) for Windows, Linux and macOS.  
+A fork of [Mesen2](https://github.com/SourMesen/Mesen2) with a **native Model Context Protocol server** built into the emulator. Same 9-system emulation core (NES, SNES, GB, GBA, PCE, SMS/GG, WS) — but launchable as a headless agent that an LLM, a test harness, or a CI job can drive over a TCP socket.
 
-## Releases
+Where vanilla Mesen has a Lua scripting console, this fork adds:
 
-The latest stable version is available from the [releases on GitHub](https://github.com/SourMesen/Mesen2/releases).  
+- A **`--mcp`** launch mode: loads a ROM, brings the emulator to max speed, listens on `127.0.0.1:7333`.
+- **30+ JSON-RPC tools** for memory I/O, screenshots, save states, audio capture, symbol lookup, disassembly, hook registration, and more.
+- **Bidirectional notifications** so a hook on a CPU instruction or memory write is delivered to the client mid-frame, not polled.
+- A **Python client library** (`mcp_client.py`) and a small SKILL document (`AGENTS.md`) that any LLM coding agent can read first to be productive in five minutes.
 
-## Development Builds
+If you've ever cursed at `tools/run_mesen.bat | grep ...` for the tenth time, this is the fix.
 
-[![Mesen](https://github.com/SourMesen/Mesen2/actions/workflows/build.yml/badge.svg)](https://github.com/SourMesen/Mesen2/actions/workflows/build.yml)
+## Quick start
 
-#### <ins>Native builds</ins> (recommended) ####
+```bash
+# Build (Windows; CL/Visual Studio + .NET 8)
+msbuild Mesen.sln /p:Configuration=Release /p:Platform=x64 /t:Core,InteropDLL
+dotnet build UI/UI.csproj -c Release
 
-These builds don't require .NET to be installed.  
+# Launch headless on port 7333
+Mesen.exe --mcp /path/to/your.sfc
 
-* [Windows 10 / 11](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net8.0%20-%20AoT%29.zip)  
-* [Linux x64](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04%20-%20clang_aot%29.zip)  (requires **SDL2**)
-* [macOS - Intel](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-13%20-%20clang_aot%29.zip)  (requires **SDL2**)
-* [macOS - Apple Silicon](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-14%20-%20clang_aot%29.zip)  (requires **SDL2**)
+# In another terminal, drive it from Python
+python3 -c "
+import socket, json
+s = socket.create_connection(('127.0.0.1', 7333))
+s.sendall(b'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n')
+print(s.recv(4096))
+"
+```
 
-#### <ins>.NET builds</ins> ####
+For a Python client with typed methods, copy [`mcp_client.py`](https://github.com/astrobleem/Mesen2/blob/master/AGENTS.md) and:
 
-These builds require **.NET 8** to be installed (except the Windows 7 build which requires .NET 6).  
-For Linux and macOS, **SDL2** must also be installed.
+```python
+from mcp_client import McpSession
 
-* [Windows 7 / 8 (.NET 6)](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net6.0%29.zip)  
-* [Linux x64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)  
-* [Linux ARM64](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang%29.zip)  
-* [Linux ARM64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)
+with McpSession(rom='path/to/game.sfc') as m:
+    m.run_frames(500)                                  # advance emulation
+    m.add_write_hook(0x7E0123)                         # WRAM write watcher
+    m.run_frames(60)
+    for evt in m.drain_notifications():                # async events
+        print(evt['params'])                           # {handle, address, value, frame}
+    shot = m.take_screenshot()                         # writes a PNG
+    state = m.get_audio_state()                        # SPC700 + DSP voices
+    m.save_state_slot(0)                               # checkpoint
+```
 
+## What's in the protocol
 
-#### <ins>Notes</ins> ####
+JSON-RPC 2.0 over a loopback TCP socket, newline-delimited. Server-to-client notifications use `notifications/mesen/hookFired` (no `id`).
 
-Other builds are also available in the [Actions](https://github.com/SourMesen/Mesen2/actions) tab.
+**Tools** (30):
 
-**SteamOS**: See [SteamOS.md](SteamOS.md)
+| Group | Tools |
+|---|---|
+| Session | `initialize`, `shutdown`, `ping` |
+| Control | `pause`, `resume`, `run_frames`, `run_until`, `reset_emulator` |
+| State | `get_state`, `get_ppu_state`, `get_audio_state`, `read_dma_state`, `hook_diag` |
+| Memory | `read_memory`, `write_memory` |
+| Hooks (event push) | `add_exec_hook`, `add_read_hook`, `add_write_hook`, `add_frame_hook`, `remove_hook`, `list_hooks` |
+| Symbols / disasm | `lookup_symbol` (WLA-DX `.sym`), `disassemble` |
+| Screenshots | `take_screenshot`, `crop_screenshot` |
+| Save states | `save_state`, `load_state`, `save_state_slot`, `load_state_slot` |
+| Audio | `record_audio`, `stop_audio` |
+| Input | `set_input` |
+
+Hooks support an optional `matchValue` + `matchValueMask` so a watch on a hot address (every-instruction, every-memory-byte) can be filtered server-side and never floods the socket.
+
+Full protocol notes for AI coding agents are in **[AGENTS.md](AGENTS.md)**.
+
+## What this fork adds (vs upstream Mesen)
+
+| Layer | File(s) | Purpose |
+|---|---|---|
+| Core/MCP server | `Core/Mcp/McpHookManager.{h,cpp}` | Thread-safe hook registry; emitter on emulator thread; bounded event queue. |
+| Debugger hooks | `Core/Debugger/Debugger.{h,cpp}` | One extra `if(_mcpHooks->HasAnyHooks())` per memory hot path; cost is one atomic-bool load when no hooks are registered. |
+| Stdout discipline | `Core/Debugger/Debugger.cpp`, `Core/Debugger/ScriptingContext.cpp` | New `EmulationFlags::McpMode` redirects debugger logs to stderr so MCP can own stdout/socket cleanly. |
+| InteropDLL exports | `InteropDLL/DebugApiWrapper.cpp`, `InteropDLL/EmuApiWrapper.cpp` | C ABI surface: `McpAddHook`, `McpRemoveHook`, `McpListHooks`, `McpDrainEvents`, `McpResetHooks`, `McpHookDiagCounters`, `GetFrameCount`, `McpResetEmu`, `McpPowerCycle`. |
+| MCP server (UI) | `UI/Utilities/Mcp/{McpServer,McpTools,McpRunner}.cs` | C# server: TCP accept loop, request dispatch, drain thread for notifications, all 30 tools. |
+| CLI | `UI/Program.cs`, `UI/Utilities/CommandLineHelper.cs` | New `--mcp` and `--mcp-port=N` flags. |
+
+The non-MCP code paths are unchanged. Vanilla Mesen workflows still work.
+
+## Releases / pre-built binaries
+
+This fork is currently source-only. Vanilla Mesen pre-builds are at the [upstream releases page](https://github.com/SourMesen/Mesen2/releases).
 
 ## Compiling
 
-See [COMPILING.md](COMPILING.md)
+See **[COMPILING.md](COMPILING.md)**. The MCP layer adds no new dependencies — it uses `System.Text.Json` (in .NET 8) and SkiaSharp (already shipped with Mesen) for crop_screenshot. No JSON library needed in C++.
+
+## Related projects
+
+- **[crlsh/mesen-mcp](https://github.com/crlsh/mesen-mcp)** — earlier C++-only Mesen-MCP fork with 6 tools and no event push. We landed on a wider tool set + bidirectional notifications, but theirs is a clean reference for the typed-command-on-emulator-thread pattern.
+- **[TheAnsarya/Nexen](https://github.com/TheAnsarya/Nexen)** — Mesen2 fork with TAS editor, ZIP movie format, and Pansy disassembly metadata. Worth reading if you need TAS-style automated input recording on top of MCP.
 
 ## License
 
-Mesen is available under the GPL V3 license.  Full text here: <http://www.gnu.org/licenses/gpl-3.0.en.html>
+This fork inherits Mesen's GPL v3.
 
-Copyright (C) 2014-2025 Sour
+Mesen is Copyright © 2014–2025 Sour.  Full text: <http://www.gnu.org/licenses/gpl-3.0.en.html>.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ print(s.recv(4096))
 "
 ```
 
-For a Python client with typed methods, copy [`mcp_client.py`](https://github.com/astrobleem/Mesen2/blob/master/AGENTS.md) and:
+A Python client with typed methods is shipped in the companion SNES project at `tools/mcp_client.py` (repo varies; see your project's `AGENTS.md`). Once on the path:
 
 ```python
 from mcp_client import McpSession

--- a/UI/Interop/ConfigApi.cs
+++ b/UI/Interop/ConfigApi.cs
@@ -58,7 +58,8 @@ namespace Mesen.Interop
 		InBackground = 0x08,
 		ConsoleMode = 0x10,
 		TestMode = 0x20,
-		OutputToStdout = 0x40
+		OutputToStdout = 0x40,
+		McpMode = 0x80,
 	}
 
 	public enum DebuggerFlags : UInt32

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -228,7 +228,8 @@ namespace Mesen.Interop
 		[DllImport(DllPath)] public static extern void SetInputOverrides(UInt32 index, DebugControllerState state);
 		[DllImport(DllPath)] private static extern void GetAvailableInputOverrides([In, Out] byte[] availableIndexes);
 
-		[DllImport(DllPath)] public static extern Int32 McpAddExecHook(CpuType cpu, UInt32 startAddr, UInt32 endAddr);
+		[DllImport(DllPath)] public static extern Int32 McpAddHook(byte kind, CpuType cpu, UInt32 startAddr, UInt32 endAddr,
+			UInt32 matchValue, UInt32 matchValueMask);
 		[DllImport(DllPath)] [return: MarshalAs(UnmanagedType.I1)] public static extern bool McpRemoveHook(Int32 handle);
 		[DllImport(DllPath)] public static extern Int32 McpListHooks([In, Out] McpHook[] buffer, Int32 maxCount);
 		[DllImport(DllPath)] public static extern Int32 McpDrainEvents([In, Out] McpHookEvent[] buffer, Int32 maxCount);
@@ -1729,6 +1730,8 @@ namespace Mesen.Interop
 	public enum McpHookKind : byte
 	{
 		Exec = 0,
+		Read = 1,
+		Write = 2,
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -1740,10 +1743,12 @@ namespace Mesen.Interop
 		public UInt16 _pad;
 		public UInt32 StartAddr;
 		public UInt32 EndAddr;
+		public UInt32 MatchValue;
+		public UInt32 MatchValueMask;
 		[MarshalAs(UnmanagedType.I1)] public bool Active;
+		[MarshalAs(UnmanagedType.I1)] public bool ValueMatchEnabled;
 		public byte _pad2a;
 		public byte _pad2b;
-		public byte _pad2c;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -1732,6 +1732,7 @@ namespace Mesen.Interop
 		Exec = 0,
 		Read = 1,
 		Write = 2,
+		Frame = 3,
 	}
 
 	[StructLayout(LayoutKind.Sequential)]

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -227,6 +227,13 @@ namespace Mesen.Interop
 		
 		[DllImport(DllPath)] public static extern void SetInputOverrides(UInt32 index, DebugControllerState state);
 		[DllImport(DllPath)] private static extern void GetAvailableInputOverrides([In, Out] byte[] availableIndexes);
+
+		[DllImport(DllPath)] public static extern Int32 McpAddExecHook(CpuType cpu, UInt32 startAddr, UInt32 endAddr);
+		[DllImport(DllPath)] [return: MarshalAs(UnmanagedType.I1)] public static extern bool McpRemoveHook(Int32 handle);
+		[DllImport(DllPath)] public static extern Int32 McpListHooks([In, Out] McpHook[] buffer, Int32 maxCount);
+		[DllImport(DllPath)] public static extern Int32 McpDrainEvents([In, Out] McpHookEvent[] buffer, Int32 maxCount);
+		[DllImport(DllPath)] public static extern void McpResetHooks();
+		[DllImport(DllPath)] public static extern void McpHookDiagCounters(out UInt64 calls, out UInt64 matches);
 		
 		public static List<int> GetAvailableInputOverrides()
 		{
@@ -1716,5 +1723,39 @@ namespace Mesen.Interop
 		[MarshalAs(UnmanagedType.I1)] public bool Right;
 		[MarshalAs(UnmanagedType.I1)] public bool Select;
 		[MarshalAs(UnmanagedType.I1)] public bool Start;
+	}
+
+	// Must match Core/Mcp/McpHookManager.h layouts byte-for-byte.
+	public enum McpHookKind : byte
+	{
+		Exec = 0,
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct McpHook
+	{
+		public Int32 Handle;
+		public McpHookKind Kind;
+		public CpuType Cpu;
+		public UInt16 _pad;
+		public UInt32 StartAddr;
+		public UInt32 EndAddr;
+		[MarshalAs(UnmanagedType.I1)] public bool Active;
+		public byte _pad2a;
+		public byte _pad2b;
+		public byte _pad2c;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct McpHookEvent
+	{
+		public Int32 Handle;
+		public UInt32 Address;
+		public UInt32 Value;
+		public UInt32 FrameNumber;
+		public McpHookKind Kind;
+		public CpuType Cpu;
+		public byte _pad0;
+		public byte _pad1;
 	}
 }

--- a/UI/Interop/EmuApi.cs
+++ b/UI/Interop/EmuApi.cs
@@ -53,6 +53,7 @@ namespace Mesen.Interop
 		[DllImport(DllPath)] [return: MarshalAs(UnmanagedType.I1)] public static extern bool IsPaused();
 
 		[DllImport(DllPath)] public static extern void TakeScreenshot();
+		[DllImport(DllPath)] public static extern UInt32 GetFrameCount();
 
 		[DllImport(DllPath)] public static extern void ProcessAudioPlayerAction(AudioPlayerActionParams p);
 

--- a/UI/Interop/EmuApi.cs
+++ b/UI/Interop/EmuApi.cs
@@ -54,6 +54,8 @@ namespace Mesen.Interop
 
 		[DllImport(DllPath)] public static extern void TakeScreenshot();
 		[DllImport(DllPath)] public static extern UInt32 GetFrameCount();
+		[DllImport(DllPath)] public static extern void McpResetEmu();
+		[DllImport(DllPath)] public static extern void McpPowerCycle();
 
 		[DllImport(DllPath)] public static extern void ProcessAudioPlayerAction(AudioPlayerActionParams p);
 

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -75,6 +75,10 @@ namespace Mesen
 				return TestRunner.Run(args);
 			}
 
+			if(CommandLineHelper.IsMcpRunner(args)) {
+				return Mesen.Utilities.Mcp.McpRunner.Run(args);
+			}
+
 			using SingleInstance instance = SingleInstance.Instance;
 			instance.Init(args);
 			if(instance.FirstInstance) {

--- a/UI/Utilities/CommandLineHelper.cs
+++ b/UI/Utilities/CommandLineHelper.cs
@@ -128,6 +128,11 @@ public class CommandLineHelper
 		return args.Any(arg => CommandLineHelper.ConvertArg(arg).ToLowerInvariant() == "testrunner");
 	}
 
+	public static bool IsMcpRunner(string[] args)
+	{
+		return args.Any(arg => CommandLineHelper.ConvertArg(arg).ToLowerInvariant() == "mcp");
+	}
+
 	public void ProcessPostLoadCommandSwitches(MainWindow wnd)
 	{
 		if(LuaScriptsToLoad.Count > 0) {

--- a/UI/Utilities/Mcp/McpRunner.cs
+++ b/UI/Utilities/Mcp/McpRunner.cs
@@ -1,0 +1,110 @@
+using Mesen.Config;
+using Mesen.Debugger.Utilities;
+using Mesen.Interop;
+using System;
+using System.IO;
+
+namespace Mesen.Utilities.Mcp;
+
+/// <summary>
+/// Entry for --mcp mode. Mirrors TestRunner.Run for ROM load / emulator
+/// bring-up, then hands control to McpServer which blocks on stdin until
+/// the client disconnects.
+/// </summary>
+internal static class McpRunner
+{
+	private const int DefaultPort = 7333;
+
+	/// <summary>Parse an explicit --mcp-port=N flag; default otherwise.</summary>
+	private static int ParsePort(string[] args)
+	{
+		foreach(string arg in args) {
+			string a = arg.StartsWith("--") ? arg.Substring(2) : arg.StartsWith("-") || arg.StartsWith("/") ? arg.Substring(1) : arg;
+			if(a.StartsWith("mcp-port=", StringComparison.OrdinalIgnoreCase)) {
+				string v = a.Substring("mcp-port=".Length);
+				if(int.TryParse(v, out int port) && port > 0 && port < 65536) {
+					return port;
+				}
+			}
+		}
+		return DefaultPort;
+	}
+
+	internal static int Run(string[] args)
+	{
+		Log("run entered");
+		ConfigManager.DisableSaveSettings = true;
+		CommandLineHelper cli = new(args, true);
+
+		if(cli.FilesToLoad.Count != 1) {
+			Log($"expected one ROM, got {cli.FilesToLoad.Count}");
+			return -1;
+		}
+
+		Log("InitDll");
+		EmuApi.InitDll();
+		Log("ApplyConfig");
+		ConfigManager.Config.ApplyConfig();
+		Log("InitializeEmu");
+		EmuApi.InitializeEmu(ConfigManager.HomeFolder, IntPtr.Zero, IntPtr.Zero, true, true, true, true);
+		Log("Pause");
+		EmuApi.Pause();
+
+		ConfigApi.SetEmulationFlag(EmulationFlags.ConsoleMode, true);
+		// Tell the C++ side that stdout belongs to MCP; Debugger/Lua logs
+		// divert to stderr.
+		ConfigApi.SetEmulationFlag(EmulationFlags.McpMode, true);
+
+		Log("LoadRom");
+		if(!EmuApi.LoadRom(cli.FilesToLoad[0], string.Empty)) {
+			Log("failed to load ROM");
+			return -1;
+		}
+
+		Log("DebugWorkspaceManager.Load");
+		DebugWorkspaceManager.Load();
+
+		// Load any Lua scripts specified on the command line — useful for
+		// seeding state before the MCP session takes over.
+		foreach(string luaScript in cli.LuaScriptsToLoad) {
+			try {
+				string script = File.ReadAllText(luaScript);
+				DebugApi.LoadScript(luaScript, Path.GetDirectoryName(luaScript) ?? Program.OriginalFolder, script);
+			} catch(Exception ex) {
+				Console.Error.WriteLine($"mcp: failed to load Lua {luaScript}: {ex.Message}");
+			}
+		}
+
+		ConfigApi.SetEmulationFlag(EmulationFlags.MaximumSpeed, true);
+		EmuApi.Resume();
+
+		// Hand control to the MCP server. Blocks until client disconnects
+		// and accept() unblocks (we rely on emu.Stop from a tool for shutdown).
+		int port = ParsePort(args);
+		Log($"McpServer on port {port}");
+		McpServer server = new(port);
+		server.Run();
+		Log("McpServer returned");
+
+		EmuApi.Stop();
+		EmuApi.Release();
+		return 0;
+	}
+
+	// Diagnostic logging — writes to a file so WinExe stdio quirks don't hide
+	// the trace. Also mirrors to stderr for console-launched usage.
+	private static string LogPath = System.IO.Path.Combine(
+		Config.ConfigManager.HomeFolder, "mcp_runner.log"
+	);
+
+	private static void Log(string message)
+	{
+		string line = $"[{DateTime.Now:HH:mm:ss.fff}] {message}";
+		try {
+			System.IO.File.AppendAllText(LogPath, line + Environment.NewLine);
+		} catch { }
+		try {
+			Console.Error.WriteLine(line);
+		} catch { }
+	}
+}

--- a/UI/Utilities/Mcp/McpRunner.cs
+++ b/UI/Utilities/Mcp/McpRunner.cs
@@ -46,7 +46,12 @@ internal static class McpRunner
 		Log("ApplyConfig");
 		ConfigManager.Config.ApplyConfig();
 		Log("InitializeEmu");
-		EmuApi.InitializeEmu(ConfigManager.HomeFolder, IntPtr.Zero, IntPtr.Zero, true, true, true, true);
+		// Enable audio (noAudio=false) so the SPC700/DSP run and record_audio
+		// can capture a real waveform. We still pass noVideo=true (we don't
+		// open an Avalonia window), and noInput=true (debugger overrides
+		// only). Audio is emulated but not pushed to the speakers in
+		// console mode unless the user explicitly wants it.
+		EmuApi.InitializeEmu(ConfigManager.HomeFolder, IntPtr.Zero, IntPtr.Zero, true, false, true, true);
 		Log("Pause");
 		EmuApi.Pause();
 

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -1,0 +1,303 @@
+using Mesen.Config;
+using Mesen.Interop;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+
+namespace Mesen.Utilities.Mcp;
+
+/// <summary>
+/// Newline-delimited JSON-RPC 2.0 server implementing a minimal subset of
+/// the Model Context Protocol. Listens on a TCP port rather than stdio —
+/// Mesen.exe is a WinExe (GUI subsystem) and its stdio handling is flaky
+/// when launched with redirected pipes. TCP is portable, simple to test
+/// from Python/Node, and leaves stdout free for debugger logs.
+///
+/// One message per line on the socket; responses one per line back. No
+/// Content-Length framing.
+///
+/// Started by McpRunner after the ROM is loaded and the emulator thread
+/// is running at max speed. Accepts one connection at a time. Returns
+/// when the client disconnects (or the server is told to shut down).
+/// </summary>
+internal sealed class McpServer
+{
+	private readonly int _port;
+	private readonly Dictionary<string, Func<JsonNode?, JsonNode>> _tools;
+	private TextReader? _in;
+	private TextWriter? _out;
+	private bool _shuttingDown;
+
+	public McpServer(int port)
+	{
+		_port = port;
+		_tools = BuildToolTable();
+	}
+
+	public void Run()
+	{
+		// Bind to loopback only so we don't open a remote attack surface;
+		// anyone with local access to the machine can connect.
+		TcpListener listener = new(IPAddress.Loopback, _port);
+		try {
+			listener.Start();
+		} catch(Exception ex) {
+			WriteLog($"[mcp] bind to port {_port} failed: {ex.Message}");
+			return;
+		}
+		WriteLog($"[mcp] listening on 127.0.0.1:{_port}; {_tools.Count} tools registered");
+
+		while(!_shuttingDown) {
+			TcpClient client;
+			try {
+				client = listener.AcceptTcpClient();
+			} catch(Exception ex) {
+				WriteLog($"[mcp] accept failed: {ex.Message}");
+				break;
+			}
+			WriteLog($"[mcp] client connected");
+			HandleClient(client);
+			WriteLog($"[mcp] client disconnected");
+		}
+
+		try {
+			listener.Stop();
+		} catch { }
+		WriteLog("[mcp] server exiting");
+	}
+
+	private void HandleClient(TcpClient client)
+	{
+		using(client)
+		using(NetworkStream stream = client.GetStream()) {
+			_in = new StreamReader(stream, new UTF8Encoding(false));
+			_out = new StreamWriter(stream, new UTF8Encoding(false)) {
+				AutoFlush = true,
+				NewLine = "\n",
+			};
+			while(!_shuttingDown) {
+				string? line;
+				try {
+					line = _in.ReadLine();
+				} catch(Exception ex) {
+					WriteLog($"[mcp] read error: {ex.Message}");
+					break;
+				}
+				if(line == null) {
+					break;
+				}
+				if(line.Length == 0) {
+					continue;
+				}
+				HandleMessage(line);
+			}
+		}
+		_in = null;
+		_out = null;
+	}
+
+	private void HandleMessage(string raw)
+	{
+		JsonNode? msg;
+		try {
+			msg = JsonNode.Parse(raw);
+		} catch(Exception ex) {
+			SendError(null, -32700, "Parse error: " + ex.Message);
+			return;
+		}
+		if(msg == null) {
+			SendError(null, -32600, "Invalid Request: empty message");
+			return;
+		}
+
+		JsonNode? idNode = msg["id"];
+		string? method = msg["method"]?.GetValue<string>();
+		JsonNode? parameters = msg["params"];
+
+		if(method == null) {
+			// No method means it's a response to something we sent — we don't
+			// send requests, so ignore / warn.
+			WriteLog("[mcp] dropping message without 'method'");
+			return;
+		}
+
+		try {
+			switch(method) {
+				case "initialize":
+					SendResult(idNode, HandleInitialize(parameters));
+					break;
+				case "initialized":
+				case "notifications/initialized":
+					// Notification, no response.
+					break;
+				case "tools/list":
+					SendResult(idNode, HandleToolsList());
+					break;
+				case "tools/call":
+					SendResult(idNode, HandleToolsCall(parameters));
+					break;
+				case "shutdown":
+					_shuttingDown = true;
+					SendResult(idNode, new JsonObject());
+					break;
+				default:
+					SendError(idNode, -32601, "Method not found: " + method);
+					break;
+			}
+		} catch(McpException mex) {
+			SendError(idNode, mex.Code, mex.Message);
+		} catch(Exception ex) {
+			SendError(idNode, -32603, "Internal error: " + ex.Message);
+		}
+	}
+
+	private JsonNode HandleInitialize(JsonNode? parameters)
+	{
+		return new JsonObject {
+			["protocolVersion"] = "2024-11-05",
+			["serverInfo"] = new JsonObject {
+				["name"] = "mesen",
+				["version"] = GetMesenVersion(),
+			},
+			["capabilities"] = new JsonObject {
+				["tools"] = new JsonObject(),
+			},
+		};
+	}
+
+	private JsonNode HandleToolsList()
+	{
+		var tools = new JsonArray();
+		foreach(var tool in McpTools.Descriptions) {
+			tools.Add(tool.ToJson());
+		}
+		return new JsonObject { ["tools"] = tools };
+	}
+
+	private JsonNode HandleToolsCall(JsonNode? parameters)
+	{
+		if(parameters == null) {
+			throw new McpException(-32602, "Missing params");
+		}
+		string? name = parameters["name"]?.GetValue<string>();
+		if(name == null) {
+			throw new McpException(-32602, "Missing params.name");
+		}
+		if(!_tools.TryGetValue(name, out var handler)) {
+			throw new McpException(-32602, "Unknown tool: " + name);
+		}
+		JsonNode? args = parameters["arguments"];
+
+		JsonNode payload;
+		try {
+			payload = handler(args);
+		} catch(McpException) {
+			throw;
+		} catch(Exception ex) {
+			// Tool-level failures surface as a content-flagged result, not a
+			// JSON-RPC error, so the model sees the error text as a tool
+			// output and can react to it.
+			return new JsonObject {
+				["content"] = new JsonArray {
+					new JsonObject {
+						["type"] = "text",
+						["text"] = $"tool {name} raised {ex.GetType().Name}: {ex.Message}",
+					},
+				},
+				["isError"] = true,
+			};
+		}
+
+		// Tools return their structured result as a JSON object; wrap it in
+		// the MCP content envelope as a single JSON-encoded text item. MCP
+		// clients expect content[].text; structured data travels inside that
+		// text body so the model sees it verbatim.
+		return new JsonObject {
+			["content"] = new JsonArray {
+				new JsonObject {
+					["type"] = "text",
+					["text"] = payload.ToJsonString(new JsonSerializerOptions { WriteIndented = false }),
+				},
+			},
+		};
+	}
+
+	private Dictionary<string, Func<JsonNode?, JsonNode>> BuildToolTable()
+	{
+		return new Dictionary<string, Func<JsonNode?, JsonNode>> {
+			["ping"] = McpTools.Ping,
+			["get_state"] = McpTools.GetState,
+			["read_memory"] = McpTools.ReadMemory,
+		};
+	}
+
+	private void SendResult(JsonNode? id, JsonNode result)
+	{
+		var response = new JsonObject {
+			["jsonrpc"] = "2.0",
+			["id"] = id?.DeepClone(),
+			["result"] = result,
+		};
+		WriteLine(response);
+	}
+
+	private void SendError(JsonNode? id, int code, string message)
+	{
+		var response = new JsonObject {
+			["jsonrpc"] = "2.0",
+			["id"] = id?.DeepClone(),
+			["error"] = new JsonObject {
+				["code"] = code,
+				["message"] = message,
+			},
+		};
+		WriteLine(response);
+	}
+
+	private void WriteLine(JsonNode node)
+	{
+		TextWriter? writer = _out;
+		if(writer == null) {
+			return;
+		}
+		lock(writer) {
+			writer.WriteLine(node.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
+		}
+	}
+
+	private static void WriteLog(string message)
+	{
+		// Logs must NOT go to stdout (that's the JSON-RPC channel). Use
+		// stderr so the parent process can still see them on demand.
+		try {
+			Console.Error.WriteLine(message);
+		} catch { }
+	}
+
+	private static string GetMesenVersion()
+	{
+		try {
+			var asm = System.Reflection.Assembly.GetExecutingAssembly();
+			var ver = asm.GetName().Version;
+			return ver?.ToString() ?? "0.0.0";
+		} catch {
+			return "0.0.0";
+		}
+	}
+}
+
+internal sealed class McpException : Exception
+{
+	public int Code { get; }
+	public McpException(int code, string message) : base(message)
+	{
+		Code = code;
+	}
+}

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -335,6 +335,12 @@ internal sealed class McpServer
 			["lookup_symbol"] = McpTools.LookupSymbol,
 			["disassemble"] = McpTools.Disassemble,
 			["run_until"] = McpTools.RunUntil,
+			["crop_screenshot"] = McpTools.CropScreenshot,
+			["save_state_slot"] = McpTools.SaveStateSlot,
+			["load_state_slot"] = McpTools.LoadStateSlot,
+			["read_dma_state"] = McpTools.ReadDmaState,
+			["add_frame_hook"] = McpTools.AddFrameHook,
+			["reset_emulator"] = McpTools.ResetEmulator,
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -242,6 +242,8 @@ internal sealed class McpServer
 			["take_screenshot"] = McpTools.TakeScreenshot,
 			["save_state"] = McpTools.SaveState,
 			["load_state"] = McpTools.LoadState,
+			["set_input"] = McpTools.SetInput,
+			["get_ppu_state"] = McpTools.GetPpuState,
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -341,6 +341,9 @@ internal sealed class McpServer
 			["read_dma_state"] = McpTools.ReadDmaState,
 			["add_frame_hook"] = McpTools.AddFrameHook,
 			["reset_emulator"] = McpTools.ResetEmulator,
+			["record_audio"] = McpTools.RecordAudio,
+			["stop_audio"] = McpTools.StopAudio,
+			["get_audio_state"] = McpTools.GetAudioState,
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -86,8 +86,10 @@ internal sealed class McpServer
 			// Kick off the event-drain pump. Reads hooks events from the
 			// emulator side via a small buffer and emits MCP notifications
 			// on this socket. Lifecycle is tied to the client: the thread
-			// exits as soon as _clientConnected flips false below.
-			Interop.DebugApi.McpResetHooks();  // defensive: start each session clean
+			// exits as soon as the cancellation token is signalled below.
+			// Note: defer the McpResetHooks call to after first message; on
+			// fresh boot the debugger isn't auto-init yet and the WithDebugger
+			// auto-init can take a noticeable moment that delays initialize.
 			var drainCts = new CancellationTokenSource();
 			var drainThread = new Thread(() => DrainLoop(drainCts.Token)) {
 				IsBackground = true,
@@ -117,7 +119,7 @@ internal sealed class McpServer
 				// so we can't race a notification write against a null writer.
 				drainCts.Cancel();
 				drainThread.Join(1000);
-				Interop.DebugApi.McpResetHooks();  // don't leak hooks to next client
+				try { Interop.DebugApi.McpResetHooks(); } catch { }  // don't leak hooks to next client
 			}
 		}
 		_in = null;
@@ -129,22 +131,29 @@ internal sealed class McpServer
 		// Buffer sized to amortize the P/Invoke cost per drain call. 256 events
 		// is ~5KB marshalled and hits well-behaved hooks once per a few frames.
 		var buf = new Interop.McpHookEvent[256];
+
+		// Pre-init the debugger so the first drain call doesn't race the
+		// main thread's WithDebugger auto-init path. Cheap if already done.
+		try { DebugApi.InitializeDebugger(); } catch { }
+
 		while(!cancel.IsCancellationRequested) {
-			int n;
+			int n = 0;
 			try {
-				n = Interop.DebugApi.McpDrainEvents(buf, buf.Length);
+				n = DebugApi.McpDrainEvents(buf, buf.Length);
 			} catch {
-				// If the debugger isn't alive (e.g. Emu shutting down), bail.
-				break;
+				// Debugger torn down between checks; just nap and re-check.
 			}
 
 			for(int i = 0; i < n; i++) {
-				SendHookNotification(buf[i]);
+				try {
+					SendHookNotification(buf[i]);
+				} catch {
+					// Socket gone; the main loop will notice via ReadLine
+					// returning null and shut us down.
+					return;
+				}
 			}
 
-			// Adaptive sleep: if we just drained a full buffer, assume more
-			// are queued and loop immediately. Otherwise sleep briefly so we
-			// don't hot-poll an idle session.
 			if(n < buf.Length) {
 				try {
 					cancel.WaitHandle.WaitOne(2);

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -82,25 +82,97 @@ internal sealed class McpServer
 				AutoFlush = true,
 				NewLine = "\n",
 			};
-			while(!_shuttingDown) {
-				string? line;
-				try {
-					line = _in.ReadLine();
-				} catch(Exception ex) {
-					WriteLog($"[mcp] read error: {ex.Message}");
-					break;
+
+			// Kick off the event-drain pump. Reads hooks events from the
+			// emulator side via a small buffer and emits MCP notifications
+			// on this socket. Lifecycle is tied to the client: the thread
+			// exits as soon as _clientConnected flips false below.
+			Interop.DebugApi.McpResetHooks();  // defensive: start each session clean
+			var drainCts = new CancellationTokenSource();
+			var drainThread = new Thread(() => DrainLoop(drainCts.Token)) {
+				IsBackground = true,
+				Name = "mcp-event-drain",
+			};
+			drainThread.Start();
+
+			try {
+				while(!_shuttingDown) {
+					string? line;
+					try {
+						line = _in.ReadLine();
+					} catch(Exception ex) {
+						WriteLog($"[mcp] read error: {ex.Message}");
+						break;
+					}
+					if(line == null) {
+						break;
+					}
+					if(line.Length == 0) {
+						continue;
+					}
+					HandleMessage(line);
 				}
-				if(line == null) {
-					break;
-				}
-				if(line.Length == 0) {
-					continue;
-				}
-				HandleMessage(line);
+			} finally {
+				// Shut down the drain thread before tearing down socket fields
+				// so we can't race a notification write against a null writer.
+				drainCts.Cancel();
+				drainThread.Join(1000);
+				Interop.DebugApi.McpResetHooks();  // don't leak hooks to next client
 			}
 		}
 		_in = null;
 		_out = null;
+	}
+
+	private void DrainLoop(CancellationToken cancel)
+	{
+		// Buffer sized to amortize the P/Invoke cost per drain call. 256 events
+		// is ~5KB marshalled and hits well-behaved hooks once per a few frames.
+		var buf = new Interop.McpHookEvent[256];
+		while(!cancel.IsCancellationRequested) {
+			int n;
+			try {
+				n = Interop.DebugApi.McpDrainEvents(buf, buf.Length);
+			} catch {
+				// If the debugger isn't alive (e.g. Emu shutting down), bail.
+				break;
+			}
+
+			for(int i = 0; i < n; i++) {
+				SendHookNotification(buf[i]);
+			}
+
+			// Adaptive sleep: if we just drained a full buffer, assume more
+			// are queued and loop immediately. Otherwise sleep briefly so we
+			// don't hot-poll an idle session.
+			if(n < buf.Length) {
+				try {
+					cancel.WaitHandle.WaitOne(2);
+				} catch {
+					break;
+				}
+			}
+		}
+	}
+
+	private void SendHookNotification(Interop.McpHookEvent evt)
+	{
+		// Notification per MCP spec: no `id`, so it's not a response.
+		// Mirror the tool-result content envelope so clients can use the same
+		// deserialize path, but flag as a notification by routing via 'method'.
+		var msg = new JsonObject {
+			["jsonrpc"] = "2.0",
+			["method"] = "notifications/mesen/hookFired",
+			["params"] = new JsonObject {
+				["handle"] = evt.Handle,
+				["kind"] = evt.Kind.ToString(),
+				["cpuType"] = evt.Cpu.ToString(),
+				["address"] = evt.Address,
+				["value"] = evt.Value,
+				["frame"] = evt.FrameNumber,
+			},
+		};
+		WriteLine(msg);
 	}
 
 	private void HandleMessage(string raw)
@@ -244,6 +316,10 @@ internal sealed class McpServer
 			["load_state"] = McpTools.LoadState,
 			["set_input"] = McpTools.SetInput,
 			["get_ppu_state"] = McpTools.GetPpuState,
+			["add_exec_hook"] = McpTools.AddExecHook,
+			["remove_hook"] = McpTools.RemoveHook,
+			["list_hooks"] = McpTools.ListHooks,
+			["hook_diag"] = McpTools.HookDiag,
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -234,7 +234,14 @@ internal sealed class McpServer
 		return new Dictionary<string, Func<JsonNode?, JsonNode>> {
 			["ping"] = McpTools.Ping,
 			["get_state"] = McpTools.GetState,
+			["pause"] = McpTools.Pause,
+			["resume"] = McpTools.Resume,
+			["run_frames"] = McpTools.RunFrames,
 			["read_memory"] = McpTools.ReadMemory,
+			["write_memory"] = McpTools.WriteMemory,
+			["take_screenshot"] = McpTools.TakeScreenshot,
+			["save_state"] = McpTools.SaveState,
+			["load_state"] = McpTools.LoadState,
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpServer.cs
+++ b/UI/Utilities/Mcp/McpServer.cs
@@ -186,6 +186,7 @@ internal sealed class McpServer
 
 	private void HandleMessage(string raw)
 	{
+		WriteLog($"[mcp] <- {raw.Substring(0, Math.Min(raw.Length, 120))}");
 		JsonNode? msg;
 		try {
 			msg = JsonNode.Parse(raw);
@@ -326,9 +327,14 @@ internal sealed class McpServer
 			["set_input"] = McpTools.SetInput,
 			["get_ppu_state"] = McpTools.GetPpuState,
 			["add_exec_hook"] = McpTools.AddExecHook,
+			["add_read_hook"] = McpTools.AddReadHook,
+			["add_write_hook"] = McpTools.AddWriteHook,
 			["remove_hook"] = McpTools.RemoveHook,
 			["list_hooks"] = McpTools.ListHooks,
 			["hook_diag"] = McpTools.HookDiag,
+			["lookup_symbol"] = McpTools.LookupSymbol,
+			["disassemble"] = McpTools.Disassemble,
+			["run_until"] = McpTools.RunUntil,
 		};
 	}
 
@@ -370,8 +376,15 @@ internal sealed class McpServer
 	{
 		// Logs must NOT go to stdout (that's the JSON-RPC channel). Use
 		// stderr so the parent process can still see them on demand.
+		// Explicit flush — Console.Error is autoflushing in theory but
+		// AppendAllText to mcp_runner.log gives us a deterministic record
+		// even when stderr is buffered/lost across the WinExe boundary.
+		string line = $"[{DateTime.Now:HH:mm:ss.fff}] {message}";
+		try { Console.Error.WriteLine(line); } catch { }
 		try {
-			Console.Error.WriteLine(message);
+			System.IO.File.AppendAllText(
+				System.IO.Path.Combine(Mesen.Config.ConfigManager.HomeFolder, "mcp_server.log"),
+				line + Environment.NewLine);
 		} catch { }
 	}
 

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -1,3 +1,4 @@
+using Mesen.Debugger;
 using Mesen.Interop;
 using System;
 using System.Collections.Generic;
@@ -84,15 +85,26 @@ internal static class McpTools
 			null),
 
 		new("add_exec_hook",
-			"Register a hook that fires when the CPU executes an instruction at a "
-				+ "specific address (or within a range). Returns a handle; use "
-				+ "remove_hook to detach. When a hook fires the server sends a "
-				+ "notifications/event message with the handle, address, and frame.",
-			BuildAddExecHookSchema()),
+			"Fire on CPU instruction execution at address (or in [address..endAddress]). "
+				+ "Returns a handle; remove_hook to detach. Per-fire the server sends "
+				+ "notifications/mesen/hookFired with handle, address, value, frame. "
+				+ "Optional matchValue+matchValueMask filters server-side so high-volume "
+				+ "PCs don't flood the socket.",
+			BuildAddHookSchema(includeValueMatch: true)),
+
+		new("add_read_hook",
+			"Fire on CPU memory reads at address (or [address..endAddress]). The "
+				+ "value field of the notification is the byte read. matchValue/Mask "
+				+ "supports the common 'fire when value == X' pattern.",
+			BuildAddHookSchema(includeValueMatch: true)),
+
+		new("add_write_hook",
+			"Fire on CPU memory writes. value = byte written. matchValue/Mask same as "
+				+ "the other hook tools.",
+			BuildAddHookSchema(includeValueMatch: true)),
 
 		new("remove_hook",
-			"Detach a previously-registered hook by handle. Returns whether the "
-				+ "handle was known.",
+			"Detach a previously-registered hook by handle.",
 			BuildRemoveHookSchema()),
 
 		new("list_hooks",
@@ -105,6 +117,26 @@ internal static class McpTools
 				+ "address-range matches since reset. Lets you confirm the hot-path "
 				+ "is alive even when no hook address has fired yet.",
 			null),
+
+		new("lookup_symbol",
+			"Resolve symbol names from a WLA-DX-format sym file. Pass the file path "
+				+ "(typically build/SuperMonkeyIsland.sym for SNES projects) and a "
+				+ "regex pattern. Returns matches with their bank:offset + 24-bit ROM "
+				+ "address ($C0|offset for HiROM bank 0). Caches the parsed file.",
+			BuildLookupSymbolSchema()),
+
+		new("disassemble",
+			"Return N disassembled instructions starting at address. Wraps Mesen's "
+				+ "GetDisassemblyOutput. Useful for one-shot 'what's at this PC' rather "
+				+ "than dragging out a hex dump.",
+			BuildDisassembleSchema()),
+
+		new("run_until",
+			"Resume emulation until any of (a) up to N frames pass, or (b) a hook fires. "
+				+ "Returns the trigger reason and (if a hook fired) which handle. "
+				+ "Atomic 'pause -> set hook -> resume -> wait -> pause' so callers "
+				+ "don't have to roll the state machine themselves.",
+			BuildRunUntilSchema()),
 	};
 
 	private static JsonNode BuildRunFramesSchema()
@@ -156,7 +188,32 @@ internal static class McpTools
 		};
 	}
 
-	private static JsonNode BuildAddExecHookSchema()
+	private static JsonNode BuildLookupSymbolSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("symFile"));
+		required.Add(JsonValue.Create("pattern"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["symFile"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "Absolute path to a WLA-DX .sym file",
+				},
+				["pattern"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "Regex pattern matched against symbol names. Use '^name$' for exact match.",
+				},
+				["maxResults"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Cap on results returned (default 64)",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildDisassembleSchema()
 	{
 		var required = new JsonArray();
 		required.Add(JsonValue.Create("address"));
@@ -165,17 +222,69 @@ internal static class McpTools
 			["properties"] = new JsonObject {
 				["address"] = new JsonObject {
 					["type"] = "integer",
-					["description"] = "Start address (inclusive)",
+					["description"] = "Start address (CPU bus, e.g. 0xC08000)",
 				},
-				["endAddress"] = new JsonObject {
+				["count"] = new JsonObject {
 					["type"] = "integer",
-					["description"] = "End address (inclusive). Defaults to address for a single-PC hook.",
+					["description"] = "Number of lines (default 16)",
 				},
 				["cpuType"] = new JsonObject {
 					["type"] = "string",
-					["description"] = "CPU type (default 'Snes'; other valid: 'Sa1', 'Spc', 'Gameboy', etc).",
+					["description"] = "CPU type (default 'Snes')",
 				},
 			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildRunUntilSchema()
+	{
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["maxFrames"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Frame budget; emulation pauses after this many frames if no hook fires (default 600).",
+				},
+				["hookHandle"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "An existing hook handle to wait on. If 0/missing, run for maxFrames and return.",
+				},
+			},
+		};
+	}
+
+	private static JsonNode BuildAddHookSchema(bool includeValueMatch)
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("address"));
+		var props = new JsonObject {
+			["address"] = new JsonObject {
+				["type"] = "integer",
+				["description"] = "Start address (inclusive)",
+			},
+			["endAddress"] = new JsonObject {
+				["type"] = "integer",
+				["description"] = "End address (inclusive). Defaults to address for a single-byte/PC hook.",
+			},
+			["cpuType"] = new JsonObject {
+				["type"] = "string",
+				["description"] = "CPU type (default 'Snes'; other valid: 'Sa1', 'Spc', 'Gameboy', etc).",
+			},
+		};
+		if(includeValueMatch) {
+			props["matchValue"] = new JsonObject {
+				["type"] = "integer",
+				["description"] = "Optional value match. Hook only fires when (observed & matchValueMask) == (matchValue & matchValueMask).",
+			};
+			props["matchValueMask"] = new JsonObject {
+				["type"] = "integer",
+				["description"] = "Mask for matchValue. 0 disables value matching (fire on every hit). 0xFF for byte-exact.",
+			};
+		}
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = props,
 			["required"] = required,
 		};
 	}
@@ -280,11 +389,10 @@ internal static class McpTools
 
 	public static JsonNode GetState(JsonNode? args)
 	{
-		// TODO expose actual frame count once we expose GetFrameCount via
-		// InteropDLL; IsRunning/IsPaused are already exported.
 		return new JsonObject {
 			["isRunning"] = EmuApi.IsRunning(),
 			["isPaused"] = EmuApi.IsPaused(),
+			["frameCount"] = EmuApi.GetFrameCount(),
 		};
 	}
 
@@ -431,9 +539,13 @@ internal static class McpTools
 		return new JsonObject { ["path"] = path };
 	}
 
-	public static JsonNode AddExecHook(JsonNode? args)
+	public static JsonNode AddExecHook(JsonNode? args) => AddHookImpl(args, McpHookKind.Exec, "add_exec_hook");
+	public static JsonNode AddReadHook(JsonNode? args) => AddHookImpl(args, McpHookKind.Read, "add_read_hook");
+	public static JsonNode AddWriteHook(JsonNode? args) => AddHookImpl(args, McpHookKind.Write, "add_write_hook");
+
+	private static JsonNode AddHookImpl(JsonNode? args, McpHookKind kind, string toolName)
 	{
-		if(args == null) throw new McpException(-32602, "add_exec_hook requires arguments");
+		if(args == null) throw new McpException(-32602, $"{toolName} requires arguments");
 		uint addr = RequireUInt(args, "address");
 		uint endAddr = (uint?)args["endAddress"]?.GetValue<long>() ?? addr;
 		string cpuStr = args["cpuType"]?.GetValue<string>() ?? "Snes";
@@ -443,12 +555,17 @@ internal static class McpTools
 		if(endAddr < addr) {
 			throw new McpException(-32602, "endAddress must be >= address");
 		}
-		int handle = DebugApi.McpAddExecHook(cpu, addr, endAddr);
+		uint matchValue = (uint)((args["matchValue"]?.GetValue<long>()) ?? 0);
+		uint matchValueMask = (uint)((args["matchValueMask"]?.GetValue<long>()) ?? 0);
+		int handle = DebugApi.McpAddHook((byte)kind, cpu, addr, endAddr, matchValue, matchValueMask);
 		return new JsonObject {
 			["handle"] = handle,
+			["kind"] = kind.ToString(),
 			["cpuType"] = cpu.ToString(),
 			["address"] = addr,
 			["endAddress"] = endAddr,
+			["matchValue"] = matchValue,
+			["matchValueMask"] = matchValueMask,
 		};
 	}
 
@@ -460,6 +577,163 @@ internal static class McpTools
 		return new JsonObject {
 			["handle"] = handle,
 			["removed"] = ok,
+		};
+	}
+
+	// Sym-file cache: filename -> (mtime, list of (name, addr)). Reparse if
+	// the file's mtime changes — typical workflow has the user rebuilding
+	// the ROM frequently and addresses shift each time.
+	private static readonly Dictionary<string, (DateTime mtime, List<(string name, uint addr)> rows)> _symCache
+		= new(StringComparer.OrdinalIgnoreCase);
+	private static readonly object _symCacheLock = new();
+
+	private static List<(string name, uint addr)> LoadSymFile(string path)
+	{
+		var info = new System.IO.FileInfo(path);
+		if(!info.Exists) {
+			throw new McpException(-32602, "sym file not found: " + path);
+		}
+		lock(_symCacheLock) {
+			if(_symCache.TryGetValue(path, out var cached) && cached.mtime == info.LastWriteTimeUtc) {
+				return cached.rows;
+			}
+			// WLA-DX format: "BBBB:OOOOOO NAME". Bank may be 4 hex digits, offset
+			// is variable width. WRAM symbols encode the $7E bank in offset.
+			var rows = new List<(string name, uint addr)>();
+			var rx = new System.Text.RegularExpressions.Regex(
+				@"^\s*[0-9A-Fa-f]{4}:([0-9A-Fa-f]+)\s+(\S+)\s*$");
+			foreach(string line in System.IO.File.ReadAllLines(path)) {
+				var m = rx.Match(line);
+				if(!m.Success) continue;
+				if(uint.TryParse(m.Groups[1].Value, System.Globalization.NumberStyles.HexNumber,
+						null, out uint addr)) {
+					rows.Add((m.Groups[2].Value, addr));
+				}
+			}
+			_symCache[path] = (info.LastWriteTimeUtc, rows);
+			return rows;
+		}
+	}
+
+	public static JsonNode LookupSymbol(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "lookup_symbol requires arguments");
+		string path = RequireString(args, "symFile");
+		string pattern = RequireString(args, "pattern");
+		int maxResults = (int)((args["maxResults"]?.GetValue<long>()) ?? 64);
+		System.Text.RegularExpressions.Regex rx;
+		try {
+			rx = new System.Text.RegularExpressions.Regex(pattern);
+		} catch(Exception ex) {
+			throw new McpException(-32602, "invalid regex: " + ex.Message);
+		}
+		var rows = LoadSymFile(path);
+		var matches = new JsonArray();
+		int count = 0;
+		foreach(var (name, addr) in rows) {
+			if(!rx.IsMatch(name)) continue;
+			// Common HiROM convenience: project's bank 0 ROM symbols (offset
+			// 0x0000..0xFFFF) run at $C0:offset at runtime. WRAM symbols
+			// already encode their full $7E:xxxx address in the offset and
+			// must not be remapped.
+			uint romCpu;
+			if(addr < 0x10000) {
+				romCpu = 0xC00000u | (addr & 0xFFFFu);
+			} else {
+				romCpu = addr;
+			}
+			matches.Add(new JsonObject {
+				["name"] = name,
+				["address"] = addr,
+				["romCpuAddr"] = romCpu,
+			});
+			if(++count >= maxResults) break;
+		}
+		return new JsonObject {
+			["count"] = count,
+			["totalSymbols"] = rows.Count,
+			["matches"] = matches,
+		};
+	}
+
+	public static JsonNode Disassemble(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "disassemble requires arguments");
+		uint addr = RequireUInt(args, "address");
+		int count = (int)((args["count"]?.GetValue<long>()) ?? 16);
+		if(count <= 0 || count > 256) throw new McpException(-32602, "count out of range (1..256)");
+		string cpuStr = args["cpuType"]?.GetValue<string>() ?? "Snes";
+		if(!Enum.TryParse<CpuType>(cpuStr, ignoreCase: true, out var cpu)) {
+			throw new McpException(-32602, "unknown cpuType: " + cpuStr);
+		}
+
+		// Get the row index for our address, then pull `count` consecutive rows.
+		int startRow = DebugApi.GetDisassemblyRowAddress(cpu, addr, 0);
+		CodeLineData[] rows = DebugApi.GetDisassemblyOutput(cpu, (uint)startRow, (uint)count);
+
+		var lines = new JsonArray();
+		foreach(var r in rows) {
+			lines.Add(new JsonObject {
+				["address"] = r.Address,
+				["text"] = r.Text,
+				["byteCode"] = Convert.ToHexString(r.ByteCode, 0, Math.Min(r.OpSize, r.ByteCode.Length)),
+				["opSize"] = r.OpSize,
+			});
+		}
+		return new JsonObject {
+			["count"] = rows.Length,
+			["lines"] = lines,
+		};
+	}
+
+	public static JsonNode RunUntil(JsonNode? args)
+	{
+		args ??= new JsonObject();
+		int maxFrames = (int)((args["maxFrames"]?.GetValue<long>()) ?? 600);
+		int hookHandle = (int)((args["hookHandle"]?.GetValue<long>()) ?? 0);
+		if(maxFrames <= 0 || maxFrames > 1_000_000) {
+			throw new McpException(-32602, "maxFrames out of range (1..1000000)");
+		}
+
+		uint startFrame = EmuApi.GetFrameCount();
+		ulong startMatches = 0;
+		if(hookHandle != 0) {
+			DebugApi.McpHookDiagCounters(out _, out startMatches);
+		}
+
+		EmuApi.Resume();
+		string reason = "maxFrames";
+		var sw = System.Diagnostics.Stopwatch.StartNew();
+		// Poll loop: every ~10ms check (a) frame budget, (b) hook firing.
+		// Cap real-time at 2x the frame-budget wall-clock just in case
+		// emulation hangs.
+		long maxMs = (long)(maxFrames * (1000.0 / 60.0) * 2.0 + 200);
+		while(sw.ElapsedMilliseconds < maxMs) {
+			System.Threading.Thread.Sleep(10);
+			uint nowFrame = EmuApi.GetFrameCount();
+			if(nowFrame - startFrame >= (uint)maxFrames) {
+				reason = "maxFrames";
+				break;
+			}
+			if(hookHandle != 0) {
+				DebugApi.McpHookDiagCounters(out _, out ulong nowMatches);
+				if(nowMatches > startMatches) {
+					reason = "hookFired";
+					break;
+				}
+			}
+		}
+		EmuApi.Pause();
+		for(int i = 0; i < 200; i++) {
+			if(EmuApi.IsPaused()) break;
+			System.Threading.Thread.Sleep(5);
+		}
+
+		uint endFrame = EmuApi.GetFrameCount();
+		return new JsonObject {
+			["reason"] = reason,
+			["framesAdvanced"] = endFrame - startFrame,
+			["isPaused"] = EmuApi.IsPaused(),
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -137,6 +137,41 @@ internal static class McpTools
 				+ "Atomic 'pause -> set hook -> resume -> wait -> pause' so callers "
 				+ "don't have to roll the state machine themselves.",
 			BuildRunUntilSchema()),
+
+		new("crop_screenshot",
+			"Capture a screenshot, then crop a region (x, y, w, h). Returns path or "
+				+ "inline base64 like take_screenshot. For UI region checks where "
+				+ "the full frame is wasted bytes.",
+			BuildCropScreenshotSchema()),
+
+		new("save_state_slot",
+			"Save emulator state to numbered slot (0..9). Cheap checkpoint without "
+				+ "managing file paths. Pair with load_state_slot to fast-forward past "
+				+ "expensive boots.",
+			BuildSlotSchema()),
+
+		new("load_state_slot",
+			"Load emulator state from numbered slot.",
+			BuildSlotSchema()),
+
+		new("read_dma_state",
+			"Snapshot the 8 DMA/HDMA channel registers ($4300-$437F). Returns each "
+				+ "channel's control / target / source / count / table addr. Critical "
+				+ "for diagnosing per-scanline register effects (BG layer enables, "
+				+ "scroll registers, palette ramps).",
+			null),
+
+		new("add_frame_hook",
+			"Fire a notification once per emulator frame. Replaces the per-frame "
+				+ "polling loop most diagnostic Lua scripts open with. The notification "
+				+ "carries the frame number; use it to pace your client without sleeping.",
+			BuildAddFrameHookSchema()),
+
+		new("reset_emulator",
+			"Soft-reset the emulator (equivalent to the SNES reset button). State "
+				+ "wiped; the ROM stays loaded. Use to start each MCP-driven test "
+				+ "from a known initial state without respawning Mesen.",
+			null),
 	};
 
 	private static JsonNode BuildRunFramesSchema()
@@ -231,6 +266,59 @@ internal static class McpTools
 				["cpuType"] = new JsonObject {
 					["type"] = "string",
 					["description"] = "CPU type (default 'Snes')",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildAddFrameHookSchema()
+	{
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["everyN"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Fire only every N-th frame (default 1, every frame). Higher values reduce notification volume.",
+				},
+				["cpuType"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "CPU type the frame is associated with (default 'Snes'). Mostly cosmetic — frames are global.",
+				},
+			},
+		};
+	}
+
+	private static JsonNode BuildCropScreenshotSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("x"));
+		required.Add(JsonValue.Create("y"));
+		required.Add(JsonValue.Create("width"));
+		required.Add(JsonValue.Create("height"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["x"] = new JsonObject { ["type"] = "integer" },
+				["y"] = new JsonObject { ["type"] = "integer" },
+				["width"] = new JsonObject { ["type"] = "integer" },
+				["height"] = new JsonObject { ["type"] = "integer" },
+				["format"] = new JsonObject { ["type"] = "string", ["description"] = "'path' or 'base64'" },
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildSlotSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("slot"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["slot"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Slot index 0..9",
 				},
 			},
 			["required"] = required,
@@ -517,6 +605,160 @@ internal static class McpTools
 			result["bytes"] = bytes.Length;
 		}
 		return result;
+	}
+
+	public static JsonNode CropScreenshot(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "crop_screenshot requires arguments");
+		int x = (int)RequireUInt(args, "x");
+		int y = (int)RequireUInt(args, "y");
+		int w = (int)RequireUInt(args, "width");
+		int h = (int)RequireUInt(args, "height");
+		if(w <= 0 || h <= 0) throw new McpException(-32602, "width and height must be > 0");
+		string format = (args["format"]?.GetValue<string>() ?? "path").ToLowerInvariant();
+
+		// Reuse the regular screenshot path so we get the same async-flush
+		// behaviour, then crop the resulting PNG.
+		var raw = (JsonObject)TakeScreenshot(new JsonObject { ["format"] = "path" });
+		string srcPath = raw["path"]!.GetValue<string>();
+
+		using var src = SkiaSharp.SKBitmap.Decode(srcPath);
+		if(src == null) {
+			throw new McpException(-32603, "failed to decode screenshot: " + srcPath);
+		}
+		// Clamp the crop rect to the image bounds rather than throwing —
+		// callers usually know the SNES is 256x224 but small mistakes are
+		// cheap to fix on the way out.
+		int clampW = Math.Min(w, src.Width - x);
+		int clampH = Math.Min(h, src.Height - y);
+		if(clampW <= 0 || clampH <= 0) {
+			throw new McpException(-32602, $"crop region ({x},{y},{w}x{h}) is outside the {src.Width}x{src.Height} screenshot");
+		}
+
+		using var dst = new SkiaSharp.SKBitmap(clampW, clampH);
+		using(var canvas = new SkiaSharp.SKCanvas(dst)) {
+			canvas.DrawBitmap(src,
+				new SkiaSharp.SKRect(x, y, x + clampW, y + clampH),
+				new SkiaSharp.SKRect(0, 0, clampW, clampH));
+		}
+
+		string cropPath = System.IO.Path.ChangeExtension(srcPath, ".crop.png");
+		using(var stream = System.IO.File.OpenWrite(cropPath))
+		using(var img = SkiaSharp.SKImage.FromBitmap(dst))
+		using(var data = img.Encode(SkiaSharp.SKEncodedImageFormat.Png, 100)) {
+			data.SaveTo(stream);
+		}
+
+		var result = new JsonObject {
+			["path"] = cropPath,
+			["width"] = clampW,
+			["height"] = clampH,
+		};
+		if(format == "base64") {
+			byte[] bytes = System.IO.File.ReadAllBytes(cropPath);
+			result["base64"] = Convert.ToBase64String(bytes);
+			result["bytes"] = bytes.Length;
+		}
+		return result;
+	}
+
+	public static JsonNode SaveStateSlot(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "save_state_slot requires arguments");
+		uint slot = RequireUInt(args, "slot");
+		if(slot > 9) throw new McpException(-32602, "slot out of range (0..9)");
+		EmuApi.SaveState(slot);
+		return new JsonObject { ["slot"] = slot };
+	}
+
+	public static JsonNode LoadStateSlot(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "load_state_slot requires arguments");
+		uint slot = RequireUInt(args, "slot");
+		if(slot > 9) throw new McpException(-32602, "slot out of range (0..9)");
+		EmuApi.LoadState(slot);
+		return new JsonObject { ["slot"] = slot };
+	}
+
+	public static JsonNode AddFrameHook(JsonNode? args)
+	{
+		args ??= new JsonObject();
+		uint everyN = (uint)((args["everyN"]?.GetValue<long>()) ?? 1);
+		if(everyN == 0) throw new McpException(-32602, "everyN must be > 0");
+		string cpuStr = args["cpuType"]?.GetValue<string>() ?? "Snes";
+		if(!Enum.TryParse<CpuType>(cpuStr, ignoreCase: true, out var cpu)) {
+			throw new McpException(-32602, "unknown cpuType: " + cpuStr);
+		}
+		// Frame number ranges over uint32; address-range check passes if we
+		// give a hook the full uint32 span. everyN is implemented via the
+		// value-match: matchValueMask = (everyN-1) and matchValue = 0 only
+		// matches when (frame & mask) == 0.
+		uint mask = everyN - 1;
+		bool isPow2 = everyN != 0 && (everyN & mask) == 0;
+		if(!isPow2) {
+			// Fallback: no value match, fire every frame and let the client filter.
+			mask = 0;
+		}
+		int handle = DebugApi.McpAddHook((byte)McpHookKind.Frame, cpu, 0, uint.MaxValue, 0, mask);
+		return new JsonObject {
+			["handle"] = handle,
+			["kind"] = "Frame",
+			["everyN"] = isPow2 ? (long)everyN : 1,
+			["cpuType"] = cpu.ToString(),
+		};
+	}
+
+	public static JsonNode ResetEmulator(JsonNode? args)
+	{
+		// Power-cycle (full reset) is what tests usually want — equivalent to
+		// flipping the cart off and back on. Soft Reset preserves more
+		// state. Default to PowerCycle so frame counter actually rewinds.
+		bool power = args?["power"]?.GetValue<bool>() ?? true;
+		if(power) {
+			EmuApi.McpPowerCycle();
+		} else {
+			EmuApi.McpResetEmu();
+		}
+		// Reset is processed on the emu thread; give it a beat to land
+		// before the caller queries state.
+		for(int i = 0; i < 60; i++) {
+			System.Threading.Thread.Sleep(20);
+			if(EmuApi.GetFrameCount() < 30) break;  // counter rewound
+		}
+		return new JsonObject { ["reset"] = true, ["power"] = power };
+	}
+
+	public static JsonNode ReadDmaState(JsonNode? args)
+	{
+		// DMA registers live at $4300..$437F (8 channels × 16 bytes).
+		// They're CPU-bus-readable in debug mode. Most fields are valid
+		// for both DMA and HDMA; the active mode + interpretation
+		// depends on the channel control register bits.
+		var channels = new JsonArray();
+		for(int ch = 0; ch < 8; ch++) {
+			uint baseAddr = (uint)(0x4300 + ch * 0x10);
+			byte[] regs = DebugApi.GetMemoryValues(MemoryType.SnesMemory, baseAddr, baseAddr + 10);
+			channels.Add(new JsonObject {
+				["channel"] = ch,
+				["control"] = regs[0],
+				["bbus"] = regs[1],
+				["aBusAddrLo"] = regs[2],
+				["aBusAddrMid"] = regs[3],
+				["aBusBank"] = regs[4],
+				["countLo"] = regs[5],
+				["countHi"] = regs[6],
+				["indirectBank"] = regs[7],
+				["tableAddrLo"] = regs[8],
+				["tableAddrHi"] = regs[9],
+				["lineCounter"] = regs[10],
+				// Convenience: 24-bit A-bus source as a single number.
+				["aBusAddr"] = (uint)(regs[2] | (regs[3] << 8) | (regs[4] << 16)),
+				["tableAddr"] = (ushort)(regs[8] | (regs[9] << 8)),
+				["count"] = (ushort)(regs[5] | (regs[6] << 8)),
+				["targetReg"] = $"$21{regs[1]:X2}",
+			});
+		}
+		return new JsonObject { ["channels"] = channels };
 	}
 
 	public static JsonNode SaveState(JsonNode? args)

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -23,16 +23,116 @@ internal static class McpTools
 			null),
 
 		new("get_state",
-			"Snapshot of emulator state: isRunning, isPaused, frameCount, romPath. "
-				+ "Frame count is authoritative — scripts no longer need to count their own.",
+			"Snapshot of emulator state: isRunning, isPaused. Emulation state "
+				+ "reads are only consistent if the emulator is paused — use pause "
+				+ "before a sequence of read_memory calls to get a coherent snapshot.",
 			null),
+
+		new("pause",
+			"Pause emulation. All read_* tools become race-free while paused. "
+				+ "Follow with resume or run_frames to advance.",
+			null),
+
+		new("resume",
+			"Resume emulation at full speed. Reads are valid but may see a moving "
+				+ "target across multiple calls.",
+			null),
+
+		new("run_frames",
+			"Advance emulation by exactly N frames, then pause again. Deterministic "
+				+ "alternative to sleeping in the client — no time-based races.",
+			BuildRunFramesSchema()),
 
 		new("read_memory",
 			"Read N bytes from a memory region. Returns hex-encoded bytes. "
-				+ "Prefer this over ad-hoc rd8/rd16 helpers — single call, reliable, "
-				+ "no per-frame-callback gymnastics.",
+				+ "Pause first for a race-free read.",
 			BuildReadMemorySchema()),
+
+		new("write_memory",
+			"Write N bytes (hex-encoded) to a memory region. Use for WRAM pokes "
+				+ "(room transitions, actor position seeds, etc). Pause the emulator "
+				+ "first if you need the write to take effect on a specific frame.",
+			BuildWriteMemorySchema()),
+
+		new("take_screenshot",
+			"Capture the current PPU frame as a PNG. Returns path (default) or "
+				+ "base64-encoded bytes. Pause first or accept mid-render.",
+			BuildScreenshotSchema()),
+
+		new("save_state",
+			"Save emulator state to a named slot or file path. Pair with load_state "
+				+ "to checkpoint expensive boots (skip intros permanently).",
+			BuildSaveLoadSchema()),
+
+		new("load_state",
+			"Load emulator state from a named slot or file path.",
+			BuildSaveLoadSchema()),
 	};
+
+	private static JsonNode BuildRunFramesSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("count"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["count"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Number of frames to advance (1..1000000)",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildWriteMemorySchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("memoryType"));
+		required.Add(JsonValue.Create("address"));
+		required.Add(JsonValue.Create("hex"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["memoryType"] = new JsonObject { ["type"] = "string" },
+				["address"] = new JsonObject { ["type"] = "integer" },
+				["hex"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "Hex-encoded bytes, no separators (e.g. 'deadbeef')",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildScreenshotSchema()
+	{
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["format"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "'path' (default; writes PNG to Screenshots folder, returns path) or 'base64' (inline PNG bytes)",
+				},
+			},
+		};
+	}
+
+	private static JsonNode BuildSaveLoadSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("path"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["path"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "File path for the save-state .mss file",
+				},
+			},
+			["required"] = required,
+		};
+	}
 
 	// Build the read_memory JSON schema imperatively. JsonArray's collection-
 	// initializer overload takes JsonNode params and ends up invoking the
@@ -82,6 +182,149 @@ internal static class McpTools
 			["isRunning"] = EmuApi.IsRunning(),
 			["isPaused"] = EmuApi.IsPaused(),
 		};
+	}
+
+	public static JsonNode Pause(JsonNode? args)
+	{
+		EmuApi.Pause();
+		// EmuApi.Pause queues the request; the emulator only actually halts
+		// on the next frame boundary. Busy-wait briefly so the next read
+		// sees a consistent state — callers would otherwise need to poll
+		// IsPaused themselves after every pause.
+		for(int i = 0; i < 200; i++) {
+			if(EmuApi.IsPaused()) break;
+			System.Threading.Thread.Sleep(5);
+		}
+		return new JsonObject { ["paused"] = EmuApi.IsPaused() };
+	}
+
+	public static JsonNode Resume(JsonNode? args)
+	{
+		EmuApi.Resume();
+		return new JsonObject { ["paused"] = false };
+	}
+
+	public static JsonNode RunFrames(JsonNode? args)
+	{
+		if(args == null) {
+			throw new McpException(-32602, "run_frames requires arguments");
+		}
+		long count = args["count"]?.GetValue<long>() ?? throw new McpException(-32602, "missing arg: count");
+		if(count <= 0 || count > 1_000_000) {
+			throw new McpException(-32602, "count out of range (1..1000000)");
+		}
+
+		// Sleep-and-pause. Not frame-accurate — max-speed mode races past
+		// N frames in much less wall-clock than 60 FPS would imply. Good
+		// enough for "advance a bit" use cases; if a tool later needs exact
+		// frame counts, add a Debug::Step hook.
+		EmuApi.Resume();
+		double estMs = count * (1000.0 / 60.0);
+		System.Threading.Thread.Sleep((int)Math.Min(estMs * 1.2 + 20, 60_000));
+		EmuApi.Pause();
+		for(int i = 0; i < 200; i++) {
+			if(EmuApi.IsPaused()) break;
+			System.Threading.Thread.Sleep(5);
+		}
+
+		return new JsonObject {
+			["requested"] = count,
+			["isPaused"] = EmuApi.IsPaused(),
+		};
+	}
+
+	public static JsonNode WriteMemory(JsonNode? args)
+	{
+		if(args == null) {
+			throw new McpException(-32602, "write_memory requires arguments");
+		}
+		string memTypeStr = RequireString(args, "memoryType");
+		uint address = RequireUInt(args, "address");
+		string hex = RequireString(args, "hex");
+		byte[] bytes;
+		try {
+			bytes = Convert.FromHexString(hex);
+		} catch {
+			throw new McpException(-32602, "hex is not a valid hex string");
+		}
+
+		MemoryType memType = ParseMemoryType(memTypeStr);
+		for(uint i = 0; i < bytes.Length; i++) {
+			DebugApi.SetMemoryValue(memType, address + i, bytes[i]);
+		}
+
+		return new JsonObject {
+			["memoryType"] = memTypeStr,
+			["address"] = address,
+			["length"] = bytes.Length,
+		};
+	}
+
+	public static JsonNode TakeScreenshot(JsonNode? args)
+	{
+		string format = (args?["format"]?.GetValue<string>() ?? "path").ToLowerInvariant();
+
+		// EmuApi.TakeScreenshot writes to the configured Screenshots folder
+		// using a timestamped filename. We capture the newest file that
+		// appears as our return path. Simple, avoids framebuffer plumbing.
+		string dir = Mesen.Config.ConfigManager.ScreenshotFolder;
+		HashSet<string> before;
+		try {
+			before = new HashSet<string>(System.IO.Directory.GetFiles(dir));
+		} catch {
+			before = new HashSet<string>();
+		}
+
+		EmuApi.TakeScreenshot();
+
+		// TakeScreenshot is async-queued; give it up to 2s to land.
+		string? path = null;
+		for(int i = 0; i < 40; i++) {
+			System.Threading.Thread.Sleep(50);
+			try {
+				foreach(string f in System.IO.Directory.GetFiles(dir, "*.png")) {
+					if(!before.Contains(f)) {
+						path = f;
+						break;
+					}
+				}
+			} catch { }
+			if(path != null) break;
+		}
+		if(path == null) {
+			throw new McpException(-32603, "TakeScreenshot did not produce a file within 2s");
+		}
+
+		var result = new JsonObject {
+			["path"] = path,
+		};
+
+		if(format == "base64") {
+			byte[] bytes = System.IO.File.ReadAllBytes(path);
+			result["base64"] = Convert.ToBase64String(bytes);
+			result["bytes"] = bytes.Length;
+		}
+		return result;
+	}
+
+	public static JsonNode SaveState(JsonNode? args)
+	{
+		if(args == null) {
+			throw new McpException(-32602, "save_state requires arguments");
+		}
+		string path = RequireString(args, "path");
+		EmuApi.SaveStateFile(path);
+		return new JsonObject { ["path"] = path };
+	}
+
+	public static JsonNode LoadState(JsonNode? args)
+	{
+		if(args == null) {
+			throw new McpException(-32602, "load_state requires arguments");
+		}
+		string path = RequireString(args, "path");
+		EmuApi.LoadStateFile(path);
+		return new JsonObject { ["path"] = path };
 	}
 
 	public static JsonNode ReadMemory(JsonNode? args)

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -172,6 +172,25 @@ internal static class McpTools
 				+ "wiped; the ROM stays loaded. Use to start each MCP-driven test "
 				+ "from a known initial state without respawning Mesen.",
 			null),
+
+		new("record_audio",
+			"Start recording emulator audio to a WAV file. Pair with stop_audio. "
+				+ "Captures the same sample stream the user would hear, so client-side "
+				+ "FFT analysis ('which voices are active', 'is the song playing the "
+				+ "right pitch') becomes possible without ears.",
+			BuildRecordAudioSchema()),
+
+		new("stop_audio",
+			"Stop the active audio recording.",
+			null),
+
+		new("get_audio_state",
+			"Snapshot SPC700 + S-DSP register state. SPC700 fields = CPU registers "
+				+ "(PC, A/X/Y, SP, flags). DSP fields include the 128-byte register "
+				+ "block — voice key-on/off, volume L/R per voice, pitch, ADSR envelope, "
+				+ "etc. Lets you ask 'what is the audio engine doing right now' rather "
+				+ "than 'what does the song sound like'.",
+			null),
 	};
 
 	private static JsonNode BuildRunFramesSchema()
@@ -266,6 +285,22 @@ internal static class McpTools
 				["cpuType"] = new JsonObject {
 					["type"] = "string",
 					["description"] = "CPU type (default 'Snes')",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildRecordAudioSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("path"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["path"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "Output .wav path. Existing files are overwritten.",
 				},
 			},
 			["required"] = required,
@@ -705,6 +740,83 @@ internal static class McpTools
 			["kind"] = "Frame",
 			["everyN"] = isPow2 ? (long)everyN : 1,
 			["cpuType"] = cpu.ToString(),
+		};
+	}
+
+	public static JsonNode RecordAudio(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "record_audio requires arguments");
+		string path = RequireString(args, "path");
+		Mesen.Interop.RecordApi.WaveRecord(path);
+		return new JsonObject { ["path"] = path, ["recording"] = true };
+	}
+
+	public static JsonNode StopAudio(JsonNode? args)
+	{
+		Mesen.Interop.RecordApi.WaveStop();
+		return new JsonObject { ["recording"] = false };
+	}
+
+	public static JsonNode GetAudioState(JsonNode? args)
+	{
+		var state = DebugApi.GetConsoleState<Mesen.Interop.SnesState>(ConsoleType.Snes);
+
+		var spc = state.Spc;
+		var dsp = state.Dsp;
+
+		// Decode the per-voice DSP register block. Each voice has 8 register
+		// slots at offsets x0..x9; voice index in high nibble. Surface the
+		// most useful subset for "is the music playing": volume L/R, pitch,
+		// source #, ADSR1/ADSR2, gain, envelope, current output.
+		var voices = new JsonArray();
+		for(int v = 0; v < 8; v++) {
+			int b = v * 0x10;
+			byte volL  = dsp.ExternalRegs[b + 0x00];
+			byte volR  = dsp.ExternalRegs[b + 0x01];
+			ushort pitch = (ushort)(dsp.ExternalRegs[b + 0x02] | (dsp.ExternalRegs[b + 0x03] << 8));
+			byte src   = dsp.ExternalRegs[b + 0x04];
+			byte adsr1 = dsp.ExternalRegs[b + 0x05];
+			byte adsr2 = dsp.ExternalRegs[b + 0x06];
+			byte gain  = dsp.ExternalRegs[b + 0x07];
+			byte envx  = dsp.ExternalRegs[b + 0x08];
+			byte outx  = dsp.ExternalRegs[b + 0x09];
+			voices.Add(new JsonObject {
+				["voice"] = v,
+				["volL"] = (sbyte)volL,
+				["volR"] = (sbyte)volR,
+				["pitch"] = pitch,
+				["sampleSrc"] = src,
+				["adsr1"] = adsr1,
+				["adsr2"] = adsr2,
+				["gain"] = gain,
+				["envelope"] = envx,
+				["currentOutput"] = (sbyte)outx,
+			});
+		}
+
+		// Master flags. $0C = MVOLL, $1C = MVOLR, $2C = EVOLL, $3C = EVOLR,
+		// $4C = KON (key on), $5C = KOF (key off), $6C = FLG (mute/reset/echo),
+		// $7C = ENDX (which voices ended).
+		return new JsonObject {
+			["spc"] = new JsonObject {
+				["pc"] = spc.PC,
+				["a"] = spc.A,
+				["x"] = spc.X,
+				["y"] = spc.Y,
+				["sp"] = spc.SP,
+				["cycle"] = spc.Cycle,
+			},
+			["dsp"] = new JsonObject {
+				["mainVolL"] = (sbyte)dsp.ExternalRegs[0x0C],
+				["mainVolR"] = (sbyte)dsp.ExternalRegs[0x1C],
+				["echoVolL"] = (sbyte)dsp.ExternalRegs[0x2C],
+				["echoVolR"] = (sbyte)dsp.ExternalRegs[0x3C],
+				["keyOn"] = dsp.ExternalRegs[0x4C],
+				["keyOff"] = dsp.ExternalRegs[0x5C],
+				["flg"] = dsp.ExternalRegs[0x6C],
+				["voicesEnded"] = dsp.ExternalRegs[0x7C],
+			},
+			["voices"] = voices,
 		};
 	}
 

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -82,6 +82,29 @@ internal static class McpTools
 				+ "scroll + tile/tilemap addrs, window config. Essential for diagnosing "
 				+ "'black scanlines' / 'missing layer' bugs without eyeball + guesswork.",
 			null),
+
+		new("add_exec_hook",
+			"Register a hook that fires when the CPU executes an instruction at a "
+				+ "specific address (or within a range). Returns a handle; use "
+				+ "remove_hook to detach. When a hook fires the server sends a "
+				+ "notifications/event message with the handle, address, and frame.",
+			BuildAddExecHookSchema()),
+
+		new("remove_hook",
+			"Detach a previously-registered hook by handle. Returns whether the "
+				+ "handle was known.",
+			BuildRemoveHookSchema()),
+
+		new("list_hooks",
+			"List currently-registered hooks. Snapshot only; hooks can fire between "
+				+ "the list call and the response.",
+			null),
+
+		new("hook_diag",
+			"Diagnostic counters: total calls into the MCP hook hot-path + total "
+				+ "address-range matches since reset. Lets you confirm the hot-path "
+				+ "is alive even when no hook address has fired yet.",
+			null),
 	};
 
 	private static JsonNode BuildRunFramesSchema()
@@ -130,6 +153,46 @@ internal static class McpTools
 					["description"] = "'path' (default; writes PNG to Screenshots folder, returns path) or 'base64' (inline PNG bytes)",
 				},
 			},
+		};
+	}
+
+	private static JsonNode BuildAddExecHookSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("address"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["address"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Start address (inclusive)",
+				},
+				["endAddress"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "End address (inclusive). Defaults to address for a single-PC hook.",
+				},
+				["cpuType"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "CPU type (default 'Snes'; other valid: 'Sa1', 'Spc', 'Gameboy', etc).",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	private static JsonNode BuildRemoveHookSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("handle"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["handle"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Handle returned from add_exec_hook.",
+				},
+			},
+			["required"] = required,
 		};
 	}
 
@@ -366,6 +429,69 @@ internal static class McpTools
 		string path = RequireString(args, "path");
 		EmuApi.LoadStateFile(path);
 		return new JsonObject { ["path"] = path };
+	}
+
+	public static JsonNode AddExecHook(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "add_exec_hook requires arguments");
+		uint addr = RequireUInt(args, "address");
+		uint endAddr = (uint?)args["endAddress"]?.GetValue<long>() ?? addr;
+		string cpuStr = args["cpuType"]?.GetValue<string>() ?? "Snes";
+		if(!Enum.TryParse<CpuType>(cpuStr, ignoreCase: true, out var cpu)) {
+			throw new McpException(-32602, "unknown cpuType: " + cpuStr);
+		}
+		if(endAddr < addr) {
+			throw new McpException(-32602, "endAddress must be >= address");
+		}
+		int handle = DebugApi.McpAddExecHook(cpu, addr, endAddr);
+		return new JsonObject {
+			["handle"] = handle,
+			["cpuType"] = cpu.ToString(),
+			["address"] = addr,
+			["endAddress"] = endAddr,
+		};
+	}
+
+	public static JsonNode RemoveHook(JsonNode? args)
+	{
+		if(args == null) throw new McpException(-32602, "remove_hook requires arguments");
+		int handle = (int)RequireUInt(args, "handle");
+		bool ok = DebugApi.McpRemoveHook(handle);
+		return new JsonObject {
+			["handle"] = handle,
+			["removed"] = ok,
+		};
+	}
+
+	public static JsonNode HookDiag(JsonNode? args)
+	{
+		DebugApi.McpHookDiagCounters(out ulong calls, out ulong matches);
+		return new JsonObject {
+			["onMemoryOperationCalls"] = calls,
+			["matchedEventsEmitted"] = matches,
+		};
+	}
+
+	public static JsonNode ListHooks(JsonNode? args)
+	{
+		var buf = new McpHook[256];
+		int n = DebugApi.McpListHooks(buf, buf.Length);
+		var arr = new JsonArray();
+		for(int i = 0; i < n; i++) {
+			var h = buf[i];
+			arr.Add(new JsonObject {
+				["handle"] = h.Handle,
+				["kind"] = h.Kind.ToString(),
+				["cpuType"] = h.Cpu.ToString(),
+				["startAddr"] = h.StartAddr,
+				["endAddr"] = h.EndAddr,
+				["active"] = h.Active,
+			});
+		}
+		return new JsonObject {
+			["count"] = n,
+			["hooks"] = arr,
+		};
 	}
 
 	public static JsonNode GetPpuState(JsonNode? args)

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -1,0 +1,198 @@
+using Mesen.Interop;
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace Mesen.Utilities.Mcp;
+
+/// <summary>
+/// MCP tool implementations. Each tool maps an arguments JsonNode to a
+/// result JsonNode. Tools throw McpException for protocol-level failures
+/// (bad args); uncaught exceptions are caught in McpServer and surfaced as
+/// isError tool results so the caller sees the failure as output.
+///
+/// Tools are intentionally small and composable — the caller orchestrates
+/// multi-step workflows, not the tool layer. If a workflow needs 4 calls,
+/// that's fine; the session is persistent and round-trips are cheap.
+/// </summary>
+internal static class McpTools
+{
+	public static readonly IReadOnlyList<McpToolDesc> Descriptions = new List<McpToolDesc> {
+		new("ping",
+			"Echo back. Use to verify the MCP session is alive.",
+			null),
+
+		new("get_state",
+			"Snapshot of emulator state: isRunning, isPaused, frameCount, romPath. "
+				+ "Frame count is authoritative — scripts no longer need to count their own.",
+			null),
+
+		new("read_memory",
+			"Read N bytes from a memory region. Returns hex-encoded bytes. "
+				+ "Prefer this over ad-hoc rd8/rd16 helpers — single call, reliable, "
+				+ "no per-frame-callback gymnastics.",
+			BuildReadMemorySchema()),
+	};
+
+	// Build the read_memory JSON schema imperatively. JsonArray's collection-
+	// initializer overload takes JsonNode params and ends up invoking the
+	// generic Add<T> path at runtime, which trips IL2026 and throws under
+	// trimming/AOT. Using explicit JsonValue.Create calls sidesteps the whole
+	// dynamic-codegen question.
+	private static JsonNode BuildReadMemorySchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("memoryType"));
+		required.Add(JsonValue.Create("address"));
+		required.Add(JsonValue.Create("length"));
+
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["memoryType"] = new JsonObject {
+					["type"] = "string",
+					["description"] = "One of: snesMemory (CPU bus), snesWorkRam, snesVideoRam, snesCgRam, snesSpriteRam, snesPrgRom, sa1Memory",
+				},
+				["address"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Start address",
+				},
+				["length"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Number of bytes to read (max 65536)",
+				},
+			},
+			["required"] = required,
+		};
+	}
+
+	public static JsonNode Ping(JsonNode? args)
+	{
+		return new JsonObject {
+			["pong"] = true,
+			["echo"] = args?.DeepClone(),
+		};
+	}
+
+	public static JsonNode GetState(JsonNode? args)
+	{
+		// TODO expose actual frame count once we expose GetFrameCount via
+		// InteropDLL; IsRunning/IsPaused are already exported.
+		return new JsonObject {
+			["isRunning"] = EmuApi.IsRunning(),
+			["isPaused"] = EmuApi.IsPaused(),
+		};
+	}
+
+	public static JsonNode ReadMemory(JsonNode? args)
+	{
+		if(args == null) {
+			throw new McpException(-32602, "read_memory requires arguments");
+		}
+		string memTypeStr = RequireString(args, "memoryType");
+		uint address = RequireUInt(args, "address");
+		uint length = RequireUInt(args, "length");
+		if(length == 0) {
+			return new JsonObject {
+				["memoryType"] = memTypeStr,
+				["address"] = address,
+				["length"] = 0,
+				["hex"] = "",
+			};
+		}
+		if(length > 65536) {
+			throw new McpException(-32602, "length > 65536");
+		}
+
+		MemoryType memType = ParseMemoryType(memTypeStr);
+		byte[] buffer = DebugApi.GetMemoryValues(memType, address, address + length - 1);
+
+		return new JsonObject {
+			["memoryType"] = memTypeStr,
+			["address"] = address,
+			["length"] = length,
+			["hex"] = Convert.ToHexString(buffer),
+		};
+	}
+
+	// --- helpers ------------------------------------------------------------
+
+	private static string RequireString(JsonNode args, string key)
+	{
+		var node = args[key];
+		if(node == null) {
+			throw new McpException(-32602, $"missing arg: {key}");
+		}
+		try {
+			return node.GetValue<string>();
+		} catch {
+			throw new McpException(-32602, $"arg {key} must be a string");
+		}
+	}
+
+	private static uint RequireUInt(JsonNode args, string key)
+	{
+		var node = args[key];
+		if(node == null) {
+			throw new McpException(-32602, $"missing arg: {key}");
+		}
+		try {
+			long v = node.GetValue<long>();
+			if(v < 0 || v > uint.MaxValue) {
+				throw new McpException(-32602, $"arg {key} out of range: {v}");
+			}
+			return (uint)v;
+		} catch(McpException) {
+			throw;
+		} catch {
+			throw new McpException(-32602, $"arg {key} must be an integer");
+		}
+	}
+
+	private static MemoryType ParseMemoryType(string name)
+	{
+		// Accept the exact Lua memType names for script portability, plus
+		// the raw enum names for callers that think in C#/C++ terms.
+		return name switch {
+			"snesMemory" => MemoryType.SnesMemory,
+			"snesWorkRam" => MemoryType.SnesWorkRam,
+			"snesVideoRam" => MemoryType.SnesVideoRam,
+			"snesCgRam" => MemoryType.SnesCgRam,
+			"snesSpriteRam" => MemoryType.SnesSpriteRam,
+			"snesPrgRom" => MemoryType.SnesPrgRom,
+			"sa1Memory" => MemoryType.Sa1Memory,
+			"sa1IRam" => MemoryType.Sa1InternalRam,
+			_ when Enum.TryParse<MemoryType>(name, ignoreCase: true, out var parsed) => parsed,
+			_ => throw new McpException(-32602, "unknown memoryType: " + name),
+		};
+	}
+}
+
+internal sealed class McpToolDesc
+{
+	public string Name { get; }
+	public string Description { get; }
+	public JsonNode? InputSchema { get; }
+
+	public McpToolDesc(string name, string description, JsonNode? inputSchema)
+	{
+		Name = name;
+		Description = description;
+		InputSchema = inputSchema;
+	}
+
+	public JsonNode ToJson()
+	{
+		var obj = new JsonObject {
+			["name"] = Name,
+			["description"] = Description,
+		};
+		// Input schema is required by the MCP spec even for no-arg tools;
+		// emit an empty object schema in that case so clients stay happy.
+		obj["inputSchema"] = InputSchema?.DeepClone() ?? new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject(),
+		};
+		return obj;
+	}
+}

--- a/UI/Utilities/Mcp/McpTools.cs
+++ b/UI/Utilities/Mcp/McpTools.cs
@@ -67,6 +67,21 @@ internal static class McpTools
 		new("load_state",
 			"Load emulator state from a named slot or file path.",
 			BuildSaveLoadSchema()),
+
+		new("set_input",
+			"Inject controller state for the next N frames. Buttons are bit-OR "
+				+ "of: a=1,b=2,select=4,start=8,up=16,down=32,left=64,right=128 and "
+				+ "SNES-only x=256,l=512,r=1024,y=2048. Use when scripts need to "
+				+ "drive past the title screen or trigger script-driven transitions "
+				+ "the way the real controller does.",
+			BuildSetInputSchema()),
+
+		new("get_ppu_state",
+			"Return PPU register snapshot: forced-blank flag, brightness, BG mode, "
+				+ "main/sub screen layer enable masks (bit0=BG1..bit4=OBJ), per-layer "
+				+ "scroll + tile/tilemap addrs, window config. Essential for diagnosing "
+				+ "'black scanlines' / 'missing layer' bugs without eyeball + guesswork.",
+			null),
 	};
 
 	private static JsonNode BuildRunFramesSchema()
@@ -115,6 +130,32 @@ internal static class McpTools
 					["description"] = "'path' (default; writes PNG to Screenshots folder, returns path) or 'base64' (inline PNG bytes)",
 				},
 			},
+		};
+	}
+
+	private static JsonNode BuildSetInputSchema()
+	{
+		var required = new JsonArray();
+		required.Add(JsonValue.Create("port"));
+		required.Add(JsonValue.Create("buttons"));
+		required.Add(JsonValue.Create("frames"));
+		return new JsonObject {
+			["type"] = "object",
+			["properties"] = new JsonObject {
+				["port"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Controller port (0 = player 1)",
+				},
+				["buttons"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "Bitmask of buttons (e.g. 8 = start)",
+				},
+				["frames"] = new JsonObject {
+					["type"] = "integer",
+					["description"] = "How many frames to hold the input; emulation advances during this window",
+				},
+			},
+			["required"] = required,
 		};
 	}
 
@@ -325,6 +366,100 @@ internal static class McpTools
 		string path = RequireString(args, "path");
 		EmuApi.LoadStateFile(path);
 		return new JsonObject { ["path"] = path };
+	}
+
+	public static JsonNode GetPpuState(JsonNode? args)
+	{
+		var s = DebugApi.GetPpuState<SnesPpuState>(CpuType.Snes);
+
+		var layers = new JsonArray();
+		for(int i = 0; i < s.Layers.Length; i++) {
+			var L = s.Layers[i];
+			layers.Add(new JsonObject {
+				["index"] = i,
+				["tilemapAddr"] = L.TilemapAddress,
+				["chrAddr"] = L.ChrAddress,
+				["hscroll"] = L.HScroll,
+				["vscroll"] = L.VScroll,
+				["largeTiles"] = L.LargeTiles,
+				["doubleWidth"] = L.DoubleWidth,
+				["doubleHeight"] = L.DoubleHeight,
+			});
+		}
+
+		var mainMask = new JsonArray();
+		var subMask = new JsonArray();
+		for(int i = 0; i < s.WindowMaskMain.Length; i++) {
+			mainMask.Add(JsonValue.Create((int)s.WindowMaskMain[i]));
+			subMask.Add(JsonValue.Create((int)s.WindowMaskSub[i]));
+		}
+
+		return new JsonObject {
+			["frameCount"] = s.FrameCount,
+			["scanline"] = s.Scanline,
+			["forcedBlank"] = s.ForcedBlank,
+			["brightness"] = s.ScreenBrightness,
+			["bgMode"] = s.BgMode,
+			["mainScreenLayers"] = s.MainScreenLayers,  // bit0=BG1 .. bit4=OBJ
+			["subScreenLayers"] = s.SubScreenLayers,
+			["mainScreenWindowMask"] = mainMask,
+			["subScreenWindowMask"] = subMask,
+			["mosaicSize"] = s.MosaicSize,
+			["mosaicEnabled"] = s.MosaicEnabled,
+			["layers"] = layers,
+		};
+	}
+
+	public static JsonNode SetInput(JsonNode? args)
+	{
+		if(args == null) {
+			throw new McpException(-32602, "set_input requires arguments");
+		}
+		uint port = RequireUInt(args, "port");
+		uint buttons = RequireUInt(args, "buttons");
+		uint frames = RequireUInt(args, "frames");
+		if(frames == 0 || frames > 100_000) {
+			throw new McpException(-32602, "frames out of range (1..100000)");
+		}
+		if(port > 3) {
+			throw new McpException(-32602, "port out of range (0..3)");
+		}
+
+		DebugControllerState state = new() {
+			A = (buttons & 0x001) != 0,
+			B = (buttons & 0x002) != 0,
+			Select = (buttons & 0x004) != 0,
+			Start = (buttons & 0x008) != 0,
+			Up = (buttons & 0x010) != 0,
+			Down = (buttons & 0x020) != 0,
+			Left = (buttons & 0x040) != 0,
+			Right = (buttons & 0x080) != 0,
+			X = (buttons & 0x100) != 0,
+			L = (buttons & 0x200) != 0,
+			R = (buttons & 0x400) != 0,
+			Y = (buttons & 0x800) != 0,
+		};
+
+		// Apply the override, run the emulator forward for the requested
+		// frames, then clear the override. Debugger input overrides win
+		// against the default controller polling every frame.
+		DebugApi.SetInputOverrides(port, state);
+		EmuApi.Resume();
+		double estMs = frames * (1000.0 / 60.0);
+		System.Threading.Thread.Sleep((int)Math.Min(estMs * 1.2 + 20, 120_000));
+		EmuApi.Pause();
+		for(int i = 0; i < 200; i++) {
+			if(EmuApi.IsPaused()) break;
+			System.Threading.Thread.Sleep(5);
+		}
+		DebugApi.SetInputOverrides(port, default);
+
+		return new JsonObject {
+			["port"] = port,
+			["buttons"] = buttons,
+			["frames"] = frames,
+			["isPaused"] = EmuApi.IsPaused(),
+		};
 	}
 
 	public static JsonNode ReadMemory(JsonNode? args)


### PR DESCRIPTION
## Summary

- Adds HiROM memory mapping to the GSU coprocessor constructor, alongside the existing LoROM path
- Checks `CartFlags::HiRom` on the loaded cartridge and branches accordingly
- LoROM path preserves **exact original** registration order and method (verified against Yoshi's Island, Star Fox 2, Winter Gold)
- Fixes a `uint16_t` overflow bug in the HiROM RAM bank mapping loops that caused an infinite loop on some compilers (Clang)

## Details

The GSU constructor previously hardcoded LoROM memory mapping. While no commercial SNES games combined HiROM with the GSU (SuperFX), the GSU-2 hardware does support it. This patch enables Mesen2 to run such cartridges.

**HiROM branch:**
- `pageIncrement=8` for banks `$00-$3F/$80-$BF:$8000-$FFFF`
- ROM at `$40-$6F` + `$72-$7D` (skipping `$70-$71` GSU RAM), mirrors at `$C0-$EF` + `$F2-$FF`
- GSU-side ROM uses linear `$0000-$FFFF` per bank
- RAM handlers registered after ROM so `$70-$71` properly overrides

**LoROM branch:** Exact original code — same registration order, same vector overloads. No behavioral changes for existing LoROM+GSU games.

## Test plan

- [x] Yoshi's Island — works correctly (regression test for LoROM path)
- [x] Star Fox 2 — works correctly
- [x] Winter Gold — works correctly
- [x] HiROM+GSU ROM loads and runs (boots, GSU registers accessible, pixel test passes)
- [x] Tested on both Windows (MSVC) and Linux (Clang 14)

Generated with [Claude Code](https://claude.com/claude-code)