### PR TITLE
GSU: 4 emulation accuracy fixes (STOP flush, R14 stall, delay underflow, restart state)

### DIFF
--- a/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
@@ -5,6 +5,11 @@
 
 void Gsu::STOP()
 {
+	// Flush pixel caches before stopping — on real hardware, STOP commits
+	// any pending pixels in the plot pipeline to the screen buffer.
+	WritePixelCache(_state.SecondaryCache);
+	WritePixelCache(_state.PrimaryCache);
+
 	if(!_state.IrqDisabled) {
 		_state.SFR.Irq = true;
 		_cpu->SetIrqSource(SnesIrqSource::Coprocessor);

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -385,8 +385,12 @@ void Gsu::WaitRamOperation()
 void Gsu::WaitForRomAccess()
 {
 	if(!_state.GsuRomAccess) {
-		_waitForRomAccess = true;
-		_stopped = true;
+		// When executing from RAM (PBR >= $60), the R14 ROM prefetch is
+		// a no-op on real hardware — don't stall the GSU for it.
+		if(_state.ProgramBank <= 0x5F) {
+			_waitForRomAccess = true;
+			_stopped = true;
+		}
 	}
 }
 

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -533,6 +533,18 @@ void Gsu::Write(uint32_t addr, uint8_t value)
 				_state.RomDelay = _state.ClockSelect ? 5 : 6;
 			} else if(addr == 0x301F) {
 				_state.SFR.Running = true;
+				_waitForRomAccess = false;
+				_waitForRamAccess = false;
+				_state.SFR.RomReadPending = false;
+				_state.RomDelay = 0;
+				_state.RamDelay = 0;
+				// Ensure CycleCount doesn't exceed master clock so Run() can execute
+				{
+					uint64_t target = _memoryManager->GetMasterClock() * _clockMultiplier;
+					if(_state.CycleCount > target) {
+						_state.CycleCount = target;
+					}
+				}
 				UpdateRunningState();
 			}
 			break;

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -434,7 +434,8 @@ void Gsu::Step(uint64_t cycles)
 	_state.CycleCount += cycles;
 
 	if(_state.RomDelay) {
-		_state.RomDelay -= std::min<uint8_t>((uint8_t)cycles, _state.RomDelay);
+		uint8_t romDec = (cycles >= _state.RomDelay) ? _state.RomDelay : (uint8_t)cycles;
+		_state.RomDelay -= romDec;
 		if(_state.RomDelay == 0) {
 			WaitForRomAccess();
 			_state.RomReadBuffer = ReadGsu((_state.RomBank << 16) | _state.R[14], MemoryOperationType::Read);
@@ -443,7 +444,8 @@ void Gsu::Step(uint64_t cycles)
 	}
 
 	if(_state.RamDelay) {
-		_state.RamDelay -= std::min<uint8_t>((uint8_t)cycles, _state.RamDelay);
+		uint8_t ramDec = (cycles >= _state.RamDelay) ? _state.RamDelay : (uint8_t)cycles;
+		_state.RamDelay -= ramDec;
 		if(_state.RamDelay == 0) {
 			WaitForRamAccess();
 			WriteGsu(0x700000 | (_state.RamBank << 16) | _state.RamWriteAddress, _state.RamWriteValue, MemoryOperationType::Write);


### PR DESCRIPTION
## Summary

Four GSU (SuperFX) emulation fixes that improve accuracy for programs executing from Game Pak RAM and using the PLOT pixel pipeline:

1. **STOP pixel cache flush** — flush both pixel caches before halting, matching real hardware behavior where STOP commits pending pixels
2. **R14 ROM stall guard** — skip ROM bus stall for R14 prefetch when executing from RAM (PBR >= $60), since the prefetch is a no-op in that context
3. **RomDelay/RamDelay underflow fix** — prevent potential underflow when the cycles parameter exceeds the uint8_t delay counter
4. **Restart state reset on GO** — clear stale wait flags, pending ROM/RAM delays, and clamp CycleCount when the SNES CPU restarts the GSU via R15H write. Instruction cache is intentionally preserved (matches real hardware)

## Context

These fixes were discovered while developing a homebrew HiROM+GSU cartridge that loads custom programs into GSU work RAM. The fixes improve accuracy for any GSU program, not just homebrew — they correct edge cases in the emulation that happen to be masked by the specific execution patterns of commercial LoROM+GSU games.

## Test plan

- [x] **Yoshi's Island** — no regressions (heaviest GSU user, restarts GSU many times per frame)
- [x] **Star Fox 2** — no regressions
- [x] **Winter Gold** — no regressions (3D polygon rendering)
- [x] Custom GSU programs executing from RAM — STOP now correctly commits final pixels

Generated with [Claude Code](https://claude.com/claude-code)